### PR TITLE
add `ingest_fn` as a param for custom python ingest fn

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,8 @@ It's similar in scope and goal to this [Airflow Anomaly Detection provider](http
 
 ### How it works
 
-1. Define your metrics (part of a ["metric batch"](#concepts)) in a `.sql` file and corresponding config in a `.yaml` file.
+1. Define your metrics (part of a ["metric batch"](#concepts)) in a `.sql` file and corresponding config in a `.yaml` file.  
+  (_Note: you can also define your own custom python ingest function instead of just SQL, check out the [`python_ingest_simple`](./metrics/examples/python_ingest/python_ingest_simple.yaml) example_)
 1. Run Anomstack and it will automatically ingest, train, score, and alert (["jobs"](#concepts)) on your metrics and detect anomalies (alerts via email/slack etc.).
 1. Get alerts when metrics look anomalous.
 

--- a/anomstack/config.py
+++ b/anomstack/config.py
@@ -51,7 +51,7 @@ with open(defaults_dir / 'defaults.yaml', 'r') as file:
 for root, dirs, files in os.walk(metrics_dir):
 
     # ignore examples if the environment variable is set
-    if os.getenv('ANOMSTACK_IGNORE_EXAMPLES') == 'yes' and examples_dir in Path(root).parents:        
+    if os.getenv('ANOMSTACK_IGNORE_EXAMPLES') == 'yes' and examples_dir in Path(root).parents:
         continue
 
     # process all the YAML files

--- a/anomstack/fn/run.py
+++ b/anomstack/fn/run.py
@@ -1,0 +1,50 @@
+"""
+Functions to read data from a python function.
+"""
+
+import ast
+from dagster import get_dagster_logger
+import pandas as pd
+
+
+def validate_function_definition(code_str: str, function_name: str) -> bool:
+    """
+    Check if the code_str contains a function definition with the given name.
+    """
+    try:
+        parsed_ast = ast.parse(code_str)
+        for node in parsed_ast.body:
+            if isinstance(node, ast.FunctionDef) and node.name == function_name:
+                return True
+        return False
+    except SyntaxError:
+        return False
+
+
+def run_ingest_fn(ingest_fn) -> pd.DataFrame:
+    """
+    Read data from a python function.
+    """
+
+    logger = get_dagster_logger()
+
+    logger.info(f'ingest_fn:\n{ingest_fn}')
+
+    # validate function definition
+    if not validate_function_definition(ingest_fn, 'ingest'):
+        raise ValueError(f"'ingest_fn' does not define a function named 'ingest'")
+
+    exec(ingest_fn)
+
+    df = locals()['ingest']()
+
+    # validate the dataframe
+    assert 'metric_name' in df.columns, 'metric_name column missing'
+    assert 'metric_value' in df.columns, 'metric_value column missing'
+    assert 'metric_timestamp' in df.columns, 'metric_timestamp column missing'
+    assert len(df.columns) == 3, 'too many columns'
+    assert len(df) > 0, 'no data returned'
+
+    logger.info(f'df:\n{df}')
+
+    return df

--- a/anomstack/jinja/render.py
+++ b/anomstack/jinja/render.py
@@ -2,14 +2,13 @@
 """
 
 from dagster import get_dagster_logger
-import pandas as pd
 import jinja2
 from jinja2 import FileSystemLoader
 
 
-def render_sql(sql_key, spec, params=None) -> str:
+def render(spec_key, spec, params=None) -> str:
     """
-    Render SQL from template.
+    Render from a templated spec key.
     """
 
     environment = jinja2.Environment(loader=FileSystemLoader('metrics/'))
@@ -17,8 +16,8 @@ def render_sql(sql_key, spec, params=None) -> str:
     if params is None:
         params = {}
 
-    sql = environment.from_string(spec[sql_key])
-    sql = sql.render(
+    rendered = environment.from_string(spec[spec_key])
+    rendered = rendered.render(
         table_key=spec.get('table_key'),
         metric_batch=spec.get('metric_batch'),
         train_max_n=spec.get('train_max_n'),
@@ -33,4 +32,4 @@ def render_sql(sql_key, spec, params=None) -> str:
         alert_always=spec.get('alert_always'),
     )
 
-    return sql
+    return rendered

--- a/anomstack/jobs/alert.py
+++ b/anomstack/jobs/alert.py
@@ -9,7 +9,7 @@ from dagster import (
 )
 from anomstack.config import specs
 from anomstack.alerts.send import send_alert
-from anomstack.sql.render import render_sql
+from anomstack.jinja.render import render
 from anomstack.sql.read import read_sql
 
 
@@ -36,7 +36,7 @@ def build_alert_job(spec) -> JobDefinition:
             """
             Get data for alerting.
             """
-            df_alerts = read_sql(render_sql('alert_sql', spec), db)
+            df_alerts = read_sql(render('alert_sql', spec), db)
             return df_alerts
 
         @op(name=f'{metric_batch}_alerts_op')

--- a/anomstack/jobs/score.py
+++ b/anomstack/jobs/score.py
@@ -9,7 +9,7 @@ from dagster import (
 )
 from anomstack.config import specs
 from anomstack.df.save import save_df
-from anomstack.sql.render import render_sql
+from anomstack.jinja.render import render
 from anomstack.sql.read import read_sql
 from anomstack.io.load import load_model
 from anomstack.ml.preprocess import make_x
@@ -44,7 +44,7 @@ def build_score_job(spec) -> JobDefinition:
             Get data for scoring.
             """
             
-            df = read_sql(render_sql('score_sql', spec), db)
+            df = read_sql(render('score_sql', spec), db)
             
             return df
 

--- a/anomstack/jobs/train.py
+++ b/anomstack/jobs/train.py
@@ -10,7 +10,7 @@ from dagster import (
 )
 from typing import List, Tuple
 from anomstack.config import specs
-from anomstack.sql.render import render_sql
+from anomstack.jinja.render import render
 from anomstack.sql.read import read_sql
 from anomstack.io.save import save_models
 from anomstack.ml.train import train_model
@@ -43,7 +43,7 @@ def build_train_job(spec) -> JobDefinition:
             Get data for training.
             """
 
-            df = read_sql(render_sql('train_sql', spec), db)
+            df = read_sql(render('train_sql', spec), db)
 
             return df
 

--- a/dagster.yaml
+++ b/dagster.yaml
@@ -9,21 +9,21 @@ run_coordinator:
 storage:
   sqlite:
     base_dir:
-      env: DAGSTER_SQLITE_STORAGE_BASE_DIR
+      env: ANOMSTACK_DAGSTER_SQLITE_STORAGE_BASE_DIR
 
 compute_logs:
   module: dagster.core.storage.local_compute_log_manager
   class: LocalComputeLogManager
   config:
     base_dir:
-      env: DAGSTER_LOCAL_COMPUTE_LOG_MANAGER_DIRECTORY
+      env: ANOMSTACK_DAGSTER_LOCAL_COMPUTE_LOG_MANAGER_DIRECTORY
 
 local_artifact_storage:
   module: dagster.core.storage.root
   class: LocalArtifactStorage
   config:
     base_dir:
-      env: DAGSTER_LOCAL_ARTIFACT_STORAGE_DIR
+      env: ANOMSTACK_DAGSTER_LOCAL_ARTIFACT_STORAGE_DIR
 
 retention:
   schedule:

--- a/metrics/examples/python/python_ingest_simple/ingest.py
+++ b/metrics/examples/python/python_ingest_simple/ingest.py
@@ -1,0 +1,22 @@
+def ingest():
+
+    import pandas as pd
+    import random
+    import time
+
+    # generate random metrics
+    metric1_value = random.uniform(0, 10)
+    metric2_value = random.uniform(0, 10)
+
+    # get current timestamp
+    current_timestamp = int(time.time())
+
+    # make df
+    data = {
+        'metric_name': ['metric1', 'metric2'],
+        'metric_value': [metric1_value, metric2_value],
+        'metric_timestamp': [current_timestamp, current_timestamp]
+        }
+    df = pd.DataFrame(data)
+
+    return df

--- a/metrics/examples/python/python_ingest_simple/python_ingest_simple.yaml
+++ b/metrics/examples/python/python_ingest_simple/python_ingest_simple.yaml
@@ -1,0 +1,8 @@
+disable_batch: False
+metric_batch: "python_ingest_simple"
+ingest_cron_schedule: "*/2 * * * *"
+train_cron_schedule: "*/4 * * * *"
+score_cron_schedule: "*/3 * * * *"
+ingest_fn: >
+  {% include "./examples/python/python_ingest_simple/ingest.py" %}
+  


### PR DESCRIPTION
- ability to define an `ingest()` function in `ingest_fn` param
- refactor `render_sql()` into `render()`
- add python function basic example