### PR TITLE
Update date filter in gsod.sql

### DIFF
--- a/metrics/examples/gsod/gsod.sql
+++ b/metrics/examples/gsod/gsod.sql
@@ -27,7 +27,7 @@ on
   and
   gsod.wban = stations.wban
 where
-  date(date) = date_add(current_date(), interval -4 day)
+  date(date) = date_add(current_date(), interval -5 day)
 ),
 
 -- US


### PR DESCRIPTION
This pull request updates the date filter in the gsod.sql file. Previously, the filter was set to select data from 4 days ago, but now it has been updated to select data from 5 days ago. This change ensures that the correct data is being retrieved for analysis.