### PR TITLE
Add metric tags functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,8 @@ Here is a list of features of Anomstack (emoji alert warning!)
 11. 🏗️ - Minimal infrastructure requirements, Anomstack just reads from and writes to whatever database you use.
 12. 📈 - A nice little local [Streamlit](https://streamlit.io/) dashboard to visualize your metrics and anomaly scores, see [#streamlit](#streamlit).
 13. 📦 - Dockerized for easy deployment.
-14. 🔔- Scores & Alerts saved to database so you can query them and do whatever you want with them.
+14. 🔔 - Scores & Alerts saved to database so you can query them and do whatever you want with them.
+15. 🏷️ - Add custom metric tags for more complex alert routing e.g. priority or subject area based.
 
 ### Architecture
 

--- a/anomstack/jobs/alert.py
+++ b/anomstack/jobs/alert.py
@@ -59,6 +59,7 @@ def build_alert_job(spec) -> JobDefinition:
     threshold = spec["alert_threshold"]
     alert_methods = spec["alert_methods"]
     table_key = spec["table_key"]
+    metric_tags = spec.get("metric_tags", {})
 
     @job(
         name=f"{metric_batch}_alerts",
@@ -110,18 +111,21 @@ def build_alert_job(spec) -> JobDefinition:
                     alert_title = (
                         f"🔥 [{metric_name}] looks anomalous ({metric_timestamp_max}) 🔥"
                     )
+                    tags = {
+                        "metric_batch": metric_batch,
+                        "metric_name": metric_name,
+                        "metric_timestamp": metric_timestamp_max,
+                        "alert_type": "ml",
+                        **metric_tags[metric_name],
+                    }
+                    logger.debug(f"metric tags:\n{tags}")
                     df_alert = send_alert(
                         metric_name=metric_name,
                         title=alert_title,
                         df=df_alert,
                         threshold=threshold,
                         alert_methods=alert_methods,
-                        tags={
-                            "metric_batch": metric_batch,
-                            "metric_name": metric_name,
-                            "metric_timestamp": metric_timestamp_max,
-                            "alert_type": "ml",
-                        },
+                        tags=tags,
                     )
 
             return df_alerts

--- a/metrics/defaults/defaults.yaml
+++ b/metrics/defaults/defaults.yaml
@@ -9,6 +9,11 @@ model_config:
   model_name: 'PCA'
   model_params:
     contamination: 0.01
+# metric_tags is a map of metric key value tags to metric names
+# metric_tags:
+#   metric_name:
+#     key1: value1
+#     key2: value2
 disable_batch: False # if you want to disable a metric batch for some reason.
 train_max_n: 1000 # max number of observations for training a model.
 train_min_n: 14 # min number of observations for training a model.

--- a/metrics/examples/bigquery/bigquery_example_simple/bigquery_example_simple.yaml
+++ b/metrics/examples/bigquery/bigquery_example_simple/bigquery_example_simple.yaml
@@ -13,6 +13,14 @@ disable_llmalert: True
 plot_cron_schedule: "*/25 * * * *" # plot every 25 minutes
 alert_always: False
 alert_methods: "email"
+# metric_tags is a map of metric key value tags to metric names
+metric_tags:
+  random_1:
+    priority: p1
+  random_2:
+    priority: p2
+  random_3:
+    priority: p3
 ingest_sql: >
   select
     *


### PR DESCRIPTION
This pull request adds the functionality to include custom metric tags in the build_alert_job function. The metric_tags parameter allows for more complex alert routing based on tags such as priority or subject area. This feature enhances the flexibility and customization of the alert system. The changes include modifications to the build_alert_job function, defaults.yaml, bigquery_example_simple.yaml, and the feature list. The pull request also includes updates to the documentation and comments to reflect the new functionality.