### PR TITLE
Refactor metric_tags to handle missing values

### DIFF
--- a/anomstack/jobs/alert.py
+++ b/anomstack/jobs/alert.py
@@ -116,7 +116,7 @@ def build_alert_job(spec) -> JobDefinition:
                         "metric_name": metric_name,
                         "metric_timestamp": metric_timestamp_max,
                         "alert_type": "ml",
-                        **metric_tags[metric_name],
+                        **metric_tags.get(metric_name,{}),
                     }
                     logger.debug(f"metric tags:\n{tags}")
                     df_alert = send_alert(

--- a/anomstack/jobs/change.py
+++ b/anomstack/jobs/change.py
@@ -138,7 +138,7 @@ def build_change_job(spec) -> JobDefinition:
                         "metric_name": metric_name,
                         "metric_timestamp": metric_timestamp_max,
                         "alert_type": "change",
-                        **metric_tags[metric_name],
+                        **metric_tags.get(metric_name,{}),
                     }
                     logger.debug(f"metric tags:\n{tags}")
                     df_alert = send_alert(

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ def read_requirements():
 
 setup(
     name='anomstack',
-    version='0.0.8',
+    version='0.0.9',
     packages=find_packages(),
     install_requires=read_requirements()
 )


### PR DESCRIPTION
This pull request refactors the `metric_tags` function to handle missing values. Previously, the function would throw an error if a metric name was not found in the `metric_tags` dictionary. This PR updates the function to use the `get` method to handle missing values gracefully, by returning an empty dictionary instead. This improves the overall robustness and reliability of the code.