### PR TITLE
Add netdata httpcheck example

### DIFF
--- a/metrics/examples/netdata_httpcheck/netdata_httpcheck.py
+++ b/metrics/examples/netdata_httpcheck/netdata_httpcheck.py
@@ -1,0 +1,110 @@
+import pandas as pd
+
+
+def ingest() -> pd.DataFrame:
+    """
+    Ingest data from Netdata API.
+    """
+
+    import pandas as pd
+    import requests
+    from dagster import get_dagster_logger
+
+    logger = get_dagster_logger()
+
+    # [(host, chart, after, before)]
+    inputs = [
+        (
+            "london.my-netdata.io",
+            "httpcheck_San_Francisco_Demo_Site_(CloudFlare).response_time",
+            "-120",
+            "0",
+        ),
+        (
+            "london.my-netdata.io",
+            "httpcheck_Frankfurt_Demo_Site_(CloudFlare).response_time",
+            "-120",
+            "0",
+        ),
+        (
+            "london.my-netdata.io",
+            "httpcheck_Toronto_Demo_Site_(CloudFlare).response_time",
+            "-120",
+            "0",
+        ),
+        (
+            "london.my-netdata.io",
+            "httpcheck_New_York_Demo_Site_(CloudFlare).response_time",
+            "-120",
+            "0",
+        ),
+        (
+            "london.my-netdata.io",
+            "httpcheck_Bangalore_Demo_Site_(CloudFlare).response_time",
+            "-120",
+            "0",
+        ),
+        (
+            "london.my-netdata.io",
+            "httpcheck_Singapore_Demo_Site_(CloudFlare).response_time",
+            "-120",
+            "0",
+        ),
+        (
+            "sanfrancisco.my-netdata.io",
+            "httpcheck_London_Demo_Site_(CloudFlare).response_time",
+            "-120",
+            "0",
+        ),
+    ]
+
+    urls = [
+        f"https://{host}/api/v1/data?chart={chart}&after={after}&before={before}&points=1&format=csv"
+        for host, chart, after, before in inputs
+    ]
+    df = pd.DataFrame()
+    for url, (host, chart, _, _) in zip(urls, inputs):
+        res = requests.get(url)
+        data = res.text.split("\r\n")
+        cols = data[0].split(",")
+        cols[0] = "metric_timestamp"
+        values = data[1].split(",")
+        df_tmp = pd.DataFrame(data=[values], columns=cols)
+        print(df_tmp)
+        df_tmp["host"] = host
+        df_tmp["chart"] = chart
+        df_tmp = df_tmp.melt(
+            id_vars=["metric_timestamp", "host", "chart"],
+            var_name="metric_name",
+            value_name="metric_value",
+        )
+        df = pd.concat([df, df_tmp])
+
+    # add host and chart prefix to metric name
+    df["metric_name"] = df["host"] + "." + df["chart"] + "." + df["metric_name"]
+
+    # add timestamp
+    df["metric_timestamp"] = pd.Timestamp.utcnow()
+
+    # clean metric_name
+    df["metric_name"] = df["metric_name"].str.replace("my-netdata.io", "", regex=False)
+    df["metric_name"] = df["metric_name"].str.replace(".", "_", regex=False)
+    df["metric_name"] = df["metric_name"].str.replace("-", "_", regex=False)
+    df["metric_name"] = df["metric_name"].str.replace("(", "_", regex=False)
+    df["metric_name"] = df["metric_name"].str.replace(")", "_", regex=False)
+    df["metric_name"] = df["metric_name"].str.replace("__", "_", regex=False)
+    df["metric_name"] = df["metric_name"].str.replace("CloudFlare", "cf", regex=False)
+    df["metric_name"] = df["metric_name"].str.lower()
+
+    df = df[["metric_timestamp", "metric_name", "metric_value"]]
+
+    logger.debug(f"df:\n{df}")
+
+    df["metric_value"] = df["metric_value"].astype(float)
+
+    return df
+
+
+if __name__ == "__main__":
+    df = ingest()
+    print(df)

--- a/metrics/examples/netdata_httpcheck/netdata_httpcheck.yaml
+++ b/metrics/examples/netdata_httpcheck/netdata_httpcheck.yaml
@@ -1,0 +1,16 @@
+metric_batch: "netdata_httpcheck"
+db: "bigquery"
+table_key: "andrewm4894.metrics.metrics"
+model_path: "gs://andrewm4894-tmp/models"
+ingest_cron_schedule: "*/10 * * * *"
+train_cron_schedule: "*/60 * * * *"
+score_cron_schedule: "*/15 * * * *"
+alert_cron_schedule: "*/20 * * * *"
+change_cron_schedule: "*/20 * * * *"
+llmalert_cron_schedule: "*/20 * * * *"
+plot_cron_schedule: "*/25 * * * *"
+alert_always: False
+disable_llmalert: False
+alert_methods: "email"
+ingest_fn: >
+  {% include "./examples/netdata_httpcheck/netdata_httpcheck.py" %}

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -8,7 +8,7 @@ logger = logging.getLogger(__name__)
 
 
 def test_jobs_len():
-    assert len(jobs) == 119
+    assert len(jobs) == 126
 
 
 def test_jobs_len_ingest():
@@ -16,7 +16,7 @@ def test_jobs_len_ingest():
 
 
 def test_schedules_len():
-    assert len(schedules) == 119
+    assert len(schedules) == 126
 
 
 def test_schedules_len_ingest():


### PR DESCRIPTION
This pull request adds an example for ingesting data from the Netdata API using the `netdata_httpcheck` metric batch. The example includes a Python script that retrieves data from multiple Netdata hosts and charts, and transforms it into a pandas DataFrame. The DataFrame is then cleaned and formatted before being returned. This example can be used as a reference for ingesting Netdata metrics into other systems or performing further analysis.