### PR TITLE
Add GraphQL documentation and examples

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ SHELL=/bin/bash
 .PHONY: docker
 .PHONY: pre-commit
 .PHONY: tests
+.PHONY: docs
 
 ## start streamlit dashboard
 dashboard:
@@ -30,61 +31,5 @@ tests:
 dev:
 	pre-commit install
 
-# Self-documenting Makefiles:
-# https://gist.github.com/klmr/575726c7e05d8780505a
-.DEFAULT_GOAL := show-help
-
-# Inspired by <http://marmelab.com/blog/2016/02/29/auto-documented-makefile.html>
-# sed script explained:
-# /^##/:
-# 	* save line in hold space
-# 	* purge line
-# 	* Loop:
-# 		* append newline + line to hold space
-# 		* go to next line
-# 		* if line starts with doc comment, strip comment character off and loop
-# 	* remove target prerequisites
-# 	* append hold space (+ newline) to line
-# 	* replace newline plus comments by `---`
-# 	* print line
-# Separate expressions are necessary because labels cannot be delimited by
-# semicolon; see <http://stackoverflow.com/a/11799865/1968>
-.PHONY: show-help
-show-help:
-	@echo "$$(tput bold)Available rules:$$(tput sgr0)"
-	@echo
-	@sed -n -e "/^## / { \
-		h; \
-		s/.*//; \
-		:doc" \
-		-e "H; \
-		n; \
-		s/^## //; \
-		t doc" \
-		-e "s/:.*//; \
-		G; \
-		s/\\n## /---/; \
-		s/\\n/ /g; \
-		p; \
-	}" ${MAKEFILE_LIST} \
-	| LC_ALL='C' sort --ignore-case \
-	| awk -F '---' \
-		-v ncol=$$(tput cols) \
-		-v indent=19 \
-		-v col_on="$$(tput setaf 6)" \
-		-v col_off="$$(tput sgr0)" \
-	'{ \
-		printf "%s%*s%s ", col_on, -indent, $$1, col_off; \
-		n = split($$2, words, " "); \
-		line_length = ncol - indent; \
-		for (i = 1; i <= n; i++) { \
-			line_length -= length(words[i]) + 1; \
-			if (line_length <= 0) { \
-				line_length = ncol - indent - length(words[i]) - 1; \
-				printf "\n%*s ", -indent, " "; \
-			} \
-			printf "%s ", words[i]; \
-		} \
-		printf "\n"; \
-	}' \
-	| more $(shell test $(shell uname) == Darwin && echo '--no-init --raw-control-chars')
+docs:
+	cd docs && yarn start

--- a/docs/docs/graphql/README.md
+++ b/docs/docs/graphql/README.md
@@ -1,0 +1,3 @@
+# GraphQL
+
+Some docs related to the GraphQL dagster endpoint.

--- a/docs/docs/graphql/examples/start_schedule.md
+++ b/docs/docs/graphql/examples/start_schedule.md
@@ -1,0 +1,812 @@
+
+# Start Schedules (GraphQL)
+
+Below is an example GraphQL query to start multiple job schedules (this avoids having to toggle them all on individually in the UI manually).
+
+You can run this via `/graphql` endpoint in the dagster UI.
+
+```graphql
+mutation {
+
+  # BigQuery
+  startBigqueryExampleSimpleAlertsSchedule: startSchedule(scheduleSelector: { 
+    scheduleName: "bigquery_example_simple_alerts_schedule", 
+    repositoryName: "__repository__", 
+    repositoryLocationName: "anomstack_code" 
+  }) {
+    __typename
+    ... on ScheduleStateResult {
+      scheduleState {
+        name
+        status
+      }
+    }
+  }
+  startBigqueryExampleSimpleChangeSchedule: startSchedule(scheduleSelector: { 
+    scheduleName: "bigquery_example_simple_change_schedule", 
+    repositoryName: "__repository__", 
+    repositoryLocationName: "anomstack_code" 
+  }) {
+    __typename
+    ... on ScheduleStateResult {
+      scheduleState {
+        name
+        status
+      }
+    }
+  }
+  startBigqueryExampleSimpleIngestSchedule: startSchedule(scheduleSelector: { 
+    scheduleName: "bigquery_example_simple_ingest_schedule", 
+    repositoryName: "__repository__", 
+    repositoryLocationName: "anomstack_code" 
+  }) {
+    __typename
+    ... on ScheduleStateResult {
+      scheduleState {
+        name
+        status
+      }
+    }
+  }
+  startBigqueryExampleSimplePlotJobSchedule: startSchedule(scheduleSelector: { 
+    scheduleName: "bigquery_example_simple_plot_job_schedule", 
+    repositoryName: "__repository__", 
+    repositoryLocationName: "anomstack_code" 
+  }) {
+    __typename
+    ... on ScheduleStateResult {
+      scheduleState {
+        name
+        status
+      }
+    }
+  }
+  startBigqueryExampleSimpleScoreSchedule: startSchedule(scheduleSelector: { 
+    scheduleName: "bigquery_example_simple_score_schedule", 
+    repositoryName: "__repository__", 
+    repositoryLocationName: "anomstack_code" 
+  }) {
+    __typename
+    ... on ScheduleStateResult {
+      scheduleState {
+        name
+        status
+      }
+    }
+  }
+  startBigqueryExampleSimpleTrainSchedule: startSchedule(scheduleSelector: { 
+    scheduleName: "bigquery_example_simple_train_schedule", 
+    repositoryName: "__repository__", 
+    repositoryLocationName: "anomstack_code" 
+  }) {
+    __typename
+    ... on ScheduleStateResult {
+      scheduleState {
+        name
+        status
+      }
+    }
+  }
+
+  # TomTom
+  startTomTomAlertsSchedule: startSchedule(scheduleSelector: { 
+    scheduleName: "tomtom_alerts_schedule", 
+    repositoryName: "__repository__", 
+    repositoryLocationName: "anomstack_code" 
+  }) {
+    __typename
+    ... on ScheduleStateResult {
+      scheduleState {
+        name
+        status
+      }
+    }
+  }
+  startTomTomChangeSchedule: startSchedule(scheduleSelector: { 
+    scheduleName: "tomtom_change_schedule", 
+    repositoryName: "__repository__", 
+    repositoryLocationName: "anomstack_code" 
+  }) {
+    __typename
+    ... on ScheduleStateResult {
+      scheduleState {
+        name
+        status
+      }
+    }
+  }
+  startTomTomIngestSchedule: startSchedule(scheduleSelector: { 
+    scheduleName: "tomtom_ingest_schedule", 
+    repositoryName: "__repository__", 
+    repositoryLocationName: "anomstack_code" 
+  }) {
+    __typename
+    ... on ScheduleStateResult {
+      scheduleState {
+        name
+        status
+      }
+    }
+  }
+  startTomTomPlotJobSchedule: startSchedule(scheduleSelector: { 
+    scheduleName: "tomtom_plot_job_schedule", 
+    repositoryName: "__repository__", 
+    repositoryLocationName: "anomstack_code" 
+  }) {
+    __typename
+    ... on ScheduleStateResult {
+      scheduleState {
+        name
+        status
+      }
+    }
+  }
+  startTomTomScoreSchedule: startSchedule(scheduleSelector: { 
+    scheduleName: "tomtom_score_schedule", 
+    repositoryName: "__repository__", 
+    repositoryLocationName: "anomstack_code" 
+  }) {
+    __typename
+    ... on ScheduleStateResult {
+      scheduleState {
+        name
+        status
+      }
+    }
+  }
+  startTomTomTrainSchedule: startSchedule(scheduleSelector: { 
+    scheduleName: "tomtom_train_schedule", 
+    repositoryName: "__repository__", 
+    repositoryLocationName: "anomstack_code" 
+  }) {
+    __typename
+    ... on ScheduleStateResult {
+      scheduleState {
+        name
+        status
+      }
+    }
+  }
+
+  # EirGrid
+  startEirGridAlertsSchedule: startSchedule(scheduleSelector: { 
+    scheduleName: "eirgrid_alerts_schedule", 
+    repositoryName: "__repository__", 
+    repositoryLocationName: "anomstack_code" 
+  }) {
+    __typename
+    ... on ScheduleStateResult {
+      scheduleState {
+        name
+        status
+      }
+    }
+  }
+  startEirGridChangeSchedule: startSchedule(scheduleSelector: { 
+    scheduleName: "eirgrid_change_schedule", 
+    repositoryName: "__repository__", 
+    repositoryLocationName: "anomstack_code" 
+  }) {
+    __typename
+    ... on ScheduleStateResult {
+      scheduleState {
+        name
+        status
+      }
+    }
+  }
+  startEirGridIngestSchedule: startSchedule(scheduleSelector: { 
+    scheduleName: "eirgrid_ingest_schedule", 
+    repositoryName: "__repository__", 
+    repositoryLocationName: "anomstack_code" 
+  }) {
+    __typename
+    ... on ScheduleStateResult {
+      scheduleState {
+        name
+        status
+      }
+    }
+  }
+  startEirGridPlotJobSchedule: startSchedule(scheduleSelector: { 
+    scheduleName: "eirgrid_plot_job_schedule", 
+    repositoryName: "__repository__", 
+    repositoryLocationName: "anomstack_code" 
+  }) {
+    __typename
+    ... on ScheduleStateResult {
+      scheduleState {
+        name
+        status
+      }
+    }
+  }
+  startEirGridScoreSchedule: startSchedule(scheduleSelector: { 
+    scheduleName: "eirgrid_score_schedule", 
+    repositoryName: "__repository__", 
+    repositoryLocationName: "anomstack_code" 
+  }) {
+    __typename
+    ... on ScheduleStateResult {
+      scheduleState {
+        name
+        status
+      }
+    }
+  }
+  startEirGridTrainSchedule: startSchedule(scheduleSelector: { 
+    scheduleName: "eirgrid_train_schedule", 
+    repositoryName: "__repository__", 
+    repositoryLocationName: "anomstack_code" 
+  }) {
+    __typename
+    ... on ScheduleStateResult {
+      scheduleState {
+        name
+        status
+      }
+    }
+  }
+
+  # Netdata
+  startNetdataAlertsSchedule: startSchedule(scheduleSelector: { 
+    scheduleName: "netdata_alerts_schedule", 
+    repositoryName: "__repository__", 
+    repositoryLocationName: "anomstack_code" 
+  }) {
+    __typename
+    ... on ScheduleStateResult {
+      scheduleState {
+        name
+        status
+      }
+    }
+  }
+  startNetdataChangeSchedule: startSchedule(scheduleSelector: { 
+    scheduleName: "netdata_change_schedule", 
+    repositoryName: "__repository__", 
+    repositoryLocationName: "anomstack_code" 
+  }) {
+    __typename
+    ... on ScheduleStateResult {
+      scheduleState {
+        name
+        status
+      }
+    }
+  }
+  startNetdataIngestSchedule: startSchedule(scheduleSelector: { 
+    scheduleName: "netdata_ingest_schedule", 
+    repositoryName: "__repository__", 
+    repositoryLocationName: "anomstack_code" 
+  }) {
+    __typename
+    ... on ScheduleStateResult {
+      scheduleState {
+        name
+        status
+      }
+    }
+  }
+  startNetdataPlotJobSchedule: startSchedule(scheduleSelector: { 
+    scheduleName: "netdata_plot_job_schedule", 
+    repositoryName: "__repository__", 
+    repositoryLocationName: "anomstack_code" 
+  }) {
+    __typename
+    ... on ScheduleStateResult {
+      scheduleState {
+        name
+        status
+      }
+    }
+  }
+  startNetdataScoreSchedule: startSchedule(scheduleSelector: { 
+    scheduleName: "netdata_score_schedule", 
+    repositoryName: "__repository__", 
+    repositoryLocationName: "anomstack_code" 
+  }) {
+    __typename
+    ... on ScheduleStateResult {
+      scheduleState {
+        name
+        status
+      }
+    }
+  }
+  startNetdataTrainSchedule: startSchedule(scheduleSelector: { 
+    scheduleName: "netdata_train_schedule", 
+    repositoryName: "__repository__", 
+    repositoryLocationName: "anomstack_code" 
+  }) {
+    __typename
+    ... on ScheduleStateResult {
+      scheduleState {
+        name
+        status
+      }
+    }
+  }
+
+  # NetdataHTTPCheck
+  startNetdataHTTPCheckAlertsSchedule: startSchedule(scheduleSelector: { 
+    scheduleName: "netdata_httpcheck_alerts_schedule", 
+    repositoryName: "__repository__", 
+    repositoryLocationName: "anomstack_code" 
+  }) {
+    __typename
+    ... on ScheduleStateResult {
+      scheduleState {
+        name
+        status
+      }
+    }
+  }
+  startNetdataHTTPCheckChangeSchedule: startSchedule(scheduleSelector: { 
+    scheduleName: "netdata_httpcheck_change_schedule", 
+    repositoryName: "__repository__", 
+    repositoryLocationName: "anomstack_code" 
+  }) {
+    __typename
+    ... on ScheduleStateResult {
+      scheduleState {
+        name
+        status
+      }
+    }
+  }
+  startNetdataHTTPCheckIngestSchedule: startSchedule(scheduleSelector: { 
+    scheduleName: "netdata_httpcheck_ingest_schedule", 
+    repositoryName: "__repository__", 
+    repositoryLocationName: "anomstack_code" 
+  }) {
+    __typename
+    ... on ScheduleStateResult {
+      scheduleState {
+        name
+        status
+      }
+    }
+  }
+  startNetdataHTTPCheckPlotJobSchedule: startSchedule(scheduleSelector: { 
+    scheduleName: "netdata_httpcheck_plot_job_schedule", 
+    repositoryName: "__repository__", 
+    repositoryLocationName: "anomstack_code" 
+  }) {
+    __typename
+    ... on ScheduleStateResult {
+      scheduleState {
+        name
+        status
+      }
+    }
+  }
+  startNetdataHTTPCheckScoreSchedule: startSchedule(scheduleSelector: { 
+    scheduleName: "netdata_httpcheck_score_schedule", 
+    repositoryName: "__repository__", 
+    repositoryLocationName: "anomstack_code" 
+  }) {
+    __typename
+    ... on ScheduleStateResult {
+      scheduleState {
+        name
+        status
+      }
+    }
+  }
+  startNetdataHTTPCheckTrainSchedule: startSchedule(scheduleSelector: { 
+    scheduleName: "netdata_httpcheck_train_schedule", 
+    repositoryName: "__repository__", 
+    repositoryLocationName: "anomstack_code" 
+  }) {
+    __typename
+    ... on ScheduleStateResult {
+      scheduleState {
+        name
+        status
+      }
+    }
+  }
+
+  # GSOD
+  startGSODAlertsSchedule: startSchedule(scheduleSelector: { 
+    scheduleName: "gsod_alerts_schedule", 
+    repositoryName: "__repository__", 
+    repositoryLocationName: "anomstack_code" 
+  }) {
+    __typename
+    ... on ScheduleStateResult {
+      scheduleState {
+        name
+        status
+      }
+    }
+  }
+  startGSODChangeSchedule: startSchedule(scheduleSelector: { 
+    scheduleName: "gsod_change_schedule", 
+    repositoryName: "__repository__", 
+    repositoryLocationName: "anomstack_code" 
+  }) {
+    __typename
+    ... on ScheduleStateResult {
+      scheduleState {
+        name
+        status
+      }
+    }
+  }
+  startGSODIngestSchedule: startSchedule(scheduleSelector: { 
+    scheduleName: "gsod_ingest_schedule", 
+    repositoryName: "__repository__", 
+    repositoryLocationName: "anomstack_code" 
+  }) {
+    __typename
+    ... on ScheduleStateResult {
+      scheduleState {
+        name
+        status
+      }
+    }
+  }
+  startGSODPlotJobSchedule: startSchedule(scheduleSelector: { 
+    scheduleName: "gsod_plot_job_schedule", 
+    repositoryName: "__repository__", 
+    repositoryLocationName: "anomstack_code" 
+  }) {
+    __typename
+    ... on ScheduleStateResult {
+      scheduleState {
+        name
+        status
+      }
+    }
+  }
+  startGSODScoreSchedule: startSchedule(scheduleSelector: { 
+    scheduleName: "gsod_score_schedule", 
+    repositoryName: "__repository__", 
+    repositoryLocationName: "anomstack_code" 
+  }) {
+    __typename
+    ... on ScheduleStateResult {
+      scheduleState {
+        name
+        status
+      }
+    }
+  }
+  startGSODTrainSchedule: startSchedule(scheduleSelector: { 
+    scheduleName: "gsod_train_schedule", 
+    repositoryName: "__repository__", 
+    repositoryLocationName: "anomstack_code" 
+  }) {
+    __typename
+    ... on ScheduleStateResult {
+      scheduleState {
+        name
+        status
+      }
+    }
+  }
+
+  # Gtrends
+  startGtrendsAlertsSchedule: startSchedule(scheduleSelector: { 
+    scheduleName: "gtrends_alerts_schedule", 
+    repositoryName: "__repository__", 
+    repositoryLocationName: "anomstack_code" 
+  }) {
+    __typename
+    ... on ScheduleStateResult {
+      scheduleState {
+        name
+        status
+      }
+    }
+  }
+  startGtrendsChangeSchedule: startSchedule(scheduleSelector: { 
+    scheduleName: "gtrends_change_schedule", 
+    repositoryName: "__repository__", 
+    repositoryLocationName: "anomstack_code" 
+  }) {
+    __typename
+    ... on ScheduleStateResult {
+      scheduleState {
+        name
+        status
+      }
+    }
+  }
+  startGtrendsIngestSchedule: startSchedule(scheduleSelector: { 
+    scheduleName: "gtrends_ingest_schedule", 
+    repositoryName: "__repository__", 
+    repositoryLocationName: "anomstack_code" 
+  }) {
+    __typename
+    ... on ScheduleStateResult {
+      scheduleState {
+        name
+        status
+      }
+    }
+  }
+  startGtrendsPlotJobSchedule: startSchedule(scheduleSelector: { 
+    scheduleName: "gtrends_plot_job_schedule", 
+    repositoryName: "__repository__", 
+    repositoryLocationName: "anomstack_code" 
+  }) {
+    __typename
+    ... on ScheduleStateResult {
+      scheduleState {
+        name
+        status
+      }
+    }
+  }
+  startGtrendsScoreSchedule: startSchedule(scheduleSelector: { 
+    scheduleName: "gtrends_score_schedule", 
+    repositoryName: "__repository__", 
+    repositoryLocationName: "anomstack_code" 
+  }) {
+    __typename
+    ... on ScheduleStateResult {
+      scheduleState {
+        name
+        status
+      }
+    }
+  }
+  startGtrendsTrainSchedule: startSchedule(scheduleSelector: { 
+    scheduleName: "gtrends_train_schedule", 
+    repositoryName: "__repository__", 
+    repositoryLocationName: "anomstack_code" 
+  }) {
+    __typename
+    ... on ScheduleStateResult {
+      scheduleState {
+        name
+        status
+      }
+    }
+  }
+
+  # YFinance
+  startYFinanceAlertsSchedule: startSchedule(scheduleSelector: { 
+    scheduleName: "yfinance_alerts_schedule", 
+    repositoryName: "__repository__", 
+    repositoryLocationName: "anomstack_code" 
+  }) {
+    __typename
+    ... on ScheduleStateResult {
+      scheduleState {
+        name
+        status
+      }
+    }
+  }
+  startYFinanceChangeSchedule: startSchedule(scheduleSelector: { 
+    scheduleName: "yfinance_change_schedule", 
+    repositoryName: "__repository__", 
+    repositoryLocationName: "anomstack_code" 
+  }) {
+    __typename
+    ... on ScheduleStateResult {
+      scheduleState {
+        name
+        status
+      }
+    }
+  }
+  startYFinanceIngestSchedule: startSchedule(scheduleSelector: { 
+    scheduleName: "yfinance_ingest_schedule", 
+    repositoryName: "__repository__", 
+    repositoryLocationName: "anomstack_code" 
+  }) {
+    __typename
+    ... on ScheduleStateResult {
+      scheduleState {
+        name
+        status
+      }
+    }
+  }
+  startYFinancePlotJobSchedule: startSchedule(scheduleSelector: { 
+    scheduleName: "yfinance_plot_job_schedule", 
+    repositoryName: "__repository__", 
+    repositoryLocationName: "anomstack_code" 
+  }) {
+    __typename
+    ... on ScheduleStateResult {
+      scheduleState {
+        name
+        status
+      }
+    }
+  }
+  startYFinanceScoreSchedule: startSchedule(scheduleSelector: { 
+    scheduleName: "yfinance_score_schedule", 
+    repositoryName: "__repository__", 
+    repositoryLocationName: "anomstack_code" 
+  }) {
+    __typename
+    ... on ScheduleStateResult {
+      scheduleState {
+        name
+        status
+      }
+    }
+  }
+  startYFinanceTrainSchedule: startSchedule(scheduleSelector: { 
+    scheduleName: "yfinance_train_schedule", 
+    repositoryName: "__repository__", 
+    repositoryLocationName: "anomstack_code" 
+  }) {
+    __typename
+    ... on ScheduleStateResult {
+      scheduleState {
+        name
+        status
+      }
+    }
+  }
+
+  # Weather
+  startWeatherAlertsSchedule: startSchedule(scheduleSelector: { 
+    scheduleName: "weather_alerts_schedule", 
+    repositoryName: "__repository__", 
+    repositoryLocationName: "anomstack_code" 
+  }) {
+    __typename
+    ... on ScheduleStateResult {
+      scheduleState {
+        name
+        status
+      }
+    }
+  }
+  startWeatherChangeSchedule: startSchedule(scheduleSelector: { 
+    scheduleName: "weather_change_schedule", 
+    repositoryName: "__repository__", 
+    repositoryLocationName: "anomstack_code" 
+  }) {
+    __typename
+    ... on ScheduleStateResult {
+      scheduleState {
+        name
+        status
+      }
+    }
+  }
+  startWeatherIngestSchedule: startSchedule(scheduleSelector: { 
+    scheduleName: "weather_ingest_schedule", 
+    repositoryName: "__repository__", 
+    repositoryLocationName: "anomstack_code" 
+  }) {
+    __typename
+    ... on ScheduleStateResult {
+      scheduleState {
+        name
+        status
+      }
+    }
+  }
+  startWeatherPlotJobSchedule: startSchedule(scheduleSelector: { 
+    scheduleName: "weather_plot_job_schedule", 
+    repositoryName: "__repository__", 
+    repositoryLocationName: "anomstack_code" 
+  }) {
+    __typename
+    ... on ScheduleStateResult {
+      scheduleState {
+        name
+        status
+      }
+    }
+  }
+  startWeatherScoreSchedule: startSchedule(scheduleSelector: { 
+    scheduleName: "weather_score_schedule", 
+    repositoryName: "__repository__", 
+    repositoryLocationName: "anomstack_code" 
+  }) {
+    __typename
+    ... on ScheduleStateResult {
+      scheduleState {
+        name
+        status
+      }
+    }
+  }
+  startWeatherTrainSchedule: startSchedule(scheduleSelector: { 
+    scheduleName: "weather_train_schedule", 
+    repositoryName: "__repository__", 
+    repositoryLocationName: "anomstack_code" 
+  }) {
+    __typename
+    ... on ScheduleStateResult {
+      scheduleState {
+        name
+        status
+      }
+    }
+  }
+
+  # HNTopStoriesScores
+  startHNTopStoriesScoresAlertsSchedule: startSchedule(scheduleSelector: { 
+    scheduleName: "hn_top_stories_scores_alerts_schedule", 
+    repositoryName: "__repository__", 
+    repositoryLocationName: "anomstack_code" 
+  }) {
+    __typename
+    ... on ScheduleStateResult {
+      scheduleState {
+        name
+        status
+      }
+    }
+  }
+  startHNTopStoriesScoresChangeSchedule: startSchedule(scheduleSelector: { 
+    scheduleName: "hn_top_stories_scores_change_schedule", 
+    repositoryName: "__repository__", 
+    repositoryLocationName: "anomstack_code" 
+  }) {
+    __typename
+    ... on ScheduleStateResult {
+      scheduleState {
+        name
+        status
+      }
+    }
+  }
+  startHNTopStoriesScoresIngestSchedule: startSchedule(scheduleSelector: { 
+    scheduleName: "hn_top_stories_scores_ingest_schedule", 
+    repositoryName: "__repository__", 
+    repositoryLocationName: "anomstack_code" 
+  }) {
+    __typename
+    ... on ScheduleStateResult {
+      scheduleState {
+        name
+        status
+      }
+    }
+  }
+  startHNTopStoriesScoresPlotJobSchedule: startSchedule(scheduleSelector: { 
+    scheduleName: "hn_top_stories_scores_plot_job_schedule", 
+    repositoryName: "__repository__", 
+    repositoryLocationName: "anomstack_code" 
+  }) {
+    __typename
+    ... on ScheduleStateResult {
+      scheduleState {
+        name
+        status
+      }
+    }
+  }
+  startHNTopStoriesScoresScoreSchedule: startSchedule(scheduleSelector: { 
+    scheduleName: "hn_top_stories_scores_score_schedule", 
+    repositoryName: "__repository__", 
+    repositoryLocationName: "anomstack_code" 
+  }) {
+    __typename
+    ... on ScheduleStateResult {
+      scheduleState {
+        name
+        status
+      }
+    }
+  }
+  startHNTopStoriesScoresTrainSchedule: startSchedule(scheduleSelector: { 
+    scheduleName: "hn_top_stories_scores_train_schedule", 
+    repositoryName: "__repository__", 
+    repositoryLocationName: "anomstack_code" 
+  }) {
+    __typename
+    ... on ScheduleStateResult {
+      scheduleState {
+        name
+        status
+      }
+    }
+  }
+
+}
+```

--- a/docs/docs/graphql/examples/start_schedule.md
+++ b/docs/docs/graphql/examples/start_schedule.md
@@ -9,10 +9,10 @@ You can run this via `/graphql` endpoint in the dagster UI.
 mutation {
 
   # BigQuery
-  startBigqueryExampleSimpleAlertsSchedule: startSchedule(scheduleSelector: { 
-    scheduleName: "bigquery_example_simple_alerts_schedule", 
-    repositoryName: "__repository__", 
-    repositoryLocationName: "anomstack_code" 
+  startBigqueryExampleSimpleAlertsSchedule: startSchedule(scheduleSelector: {
+    scheduleName: "bigquery_example_simple_alerts_schedule",
+    repositoryName: "__repository__",
+    repositoryLocationName: "anomstack_code"
   }) {
     __typename
     ... on ScheduleStateResult {
@@ -22,10 +22,10 @@ mutation {
       }
     }
   }
-  startBigqueryExampleSimpleChangeSchedule: startSchedule(scheduleSelector: { 
-    scheduleName: "bigquery_example_simple_change_schedule", 
-    repositoryName: "__repository__", 
-    repositoryLocationName: "anomstack_code" 
+  startBigqueryExampleSimpleChangeSchedule: startSchedule(scheduleSelector: {
+    scheduleName: "bigquery_example_simple_change_schedule",
+    repositoryName: "__repository__",
+    repositoryLocationName: "anomstack_code"
   }) {
     __typename
     ... on ScheduleStateResult {
@@ -35,10 +35,10 @@ mutation {
       }
     }
   }
-  startBigqueryExampleSimpleIngestSchedule: startSchedule(scheduleSelector: { 
-    scheduleName: "bigquery_example_simple_ingest_schedule", 
-    repositoryName: "__repository__", 
-    repositoryLocationName: "anomstack_code" 
+  startBigqueryExampleSimpleIngestSchedule: startSchedule(scheduleSelector: {
+    scheduleName: "bigquery_example_simple_ingest_schedule",
+    repositoryName: "__repository__",
+    repositoryLocationName: "anomstack_code"
   }) {
     __typename
     ... on ScheduleStateResult {
@@ -48,10 +48,10 @@ mutation {
       }
     }
   }
-  startBigqueryExampleSimplePlotJobSchedule: startSchedule(scheduleSelector: { 
-    scheduleName: "bigquery_example_simple_plot_job_schedule", 
-    repositoryName: "__repository__", 
-    repositoryLocationName: "anomstack_code" 
+  startBigqueryExampleSimplePlotJobSchedule: startSchedule(scheduleSelector: {
+    scheduleName: "bigquery_example_simple_plot_job_schedule",
+    repositoryName: "__repository__",
+    repositoryLocationName: "anomstack_code"
   }) {
     __typename
     ... on ScheduleStateResult {
@@ -61,10 +61,10 @@ mutation {
       }
     }
   }
-  startBigqueryExampleSimpleScoreSchedule: startSchedule(scheduleSelector: { 
-    scheduleName: "bigquery_example_simple_score_schedule", 
-    repositoryName: "__repository__", 
-    repositoryLocationName: "anomstack_code" 
+  startBigqueryExampleSimpleScoreSchedule: startSchedule(scheduleSelector: {
+    scheduleName: "bigquery_example_simple_score_schedule",
+    repositoryName: "__repository__",
+    repositoryLocationName: "anomstack_code"
   }) {
     __typename
     ... on ScheduleStateResult {
@@ -74,10 +74,10 @@ mutation {
       }
     }
   }
-  startBigqueryExampleSimpleTrainSchedule: startSchedule(scheduleSelector: { 
-    scheduleName: "bigquery_example_simple_train_schedule", 
-    repositoryName: "__repository__", 
-    repositoryLocationName: "anomstack_code" 
+  startBigqueryExampleSimpleTrainSchedule: startSchedule(scheduleSelector: {
+    scheduleName: "bigquery_example_simple_train_schedule",
+    repositoryName: "__repository__",
+    repositoryLocationName: "anomstack_code"
   }) {
     __typename
     ... on ScheduleStateResult {
@@ -89,10 +89,10 @@ mutation {
   }
 
   # TomTom
-  startTomTomAlertsSchedule: startSchedule(scheduleSelector: { 
-    scheduleName: "tomtom_alerts_schedule", 
-    repositoryName: "__repository__", 
-    repositoryLocationName: "anomstack_code" 
+  startTomTomAlertsSchedule: startSchedule(scheduleSelector: {
+    scheduleName: "tomtom_alerts_schedule",
+    repositoryName: "__repository__",
+    repositoryLocationName: "anomstack_code"
   }) {
     __typename
     ... on ScheduleStateResult {
@@ -102,10 +102,10 @@ mutation {
       }
     }
   }
-  startTomTomChangeSchedule: startSchedule(scheduleSelector: { 
-    scheduleName: "tomtom_change_schedule", 
-    repositoryName: "__repository__", 
-    repositoryLocationName: "anomstack_code" 
+  startTomTomChangeSchedule: startSchedule(scheduleSelector: {
+    scheduleName: "tomtom_change_schedule",
+    repositoryName: "__repository__",
+    repositoryLocationName: "anomstack_code"
   }) {
     __typename
     ... on ScheduleStateResult {
@@ -115,10 +115,10 @@ mutation {
       }
     }
   }
-  startTomTomIngestSchedule: startSchedule(scheduleSelector: { 
-    scheduleName: "tomtom_ingest_schedule", 
-    repositoryName: "__repository__", 
-    repositoryLocationName: "anomstack_code" 
+  startTomTomIngestSchedule: startSchedule(scheduleSelector: {
+    scheduleName: "tomtom_ingest_schedule",
+    repositoryName: "__repository__",
+    repositoryLocationName: "anomstack_code"
   }) {
     __typename
     ... on ScheduleStateResult {
@@ -128,10 +128,10 @@ mutation {
       }
     }
   }
-  startTomTomPlotJobSchedule: startSchedule(scheduleSelector: { 
-    scheduleName: "tomtom_plot_job_schedule", 
-    repositoryName: "__repository__", 
-    repositoryLocationName: "anomstack_code" 
+  startTomTomPlotJobSchedule: startSchedule(scheduleSelector: {
+    scheduleName: "tomtom_plot_job_schedule",
+    repositoryName: "__repository__",
+    repositoryLocationName: "anomstack_code"
   }) {
     __typename
     ... on ScheduleStateResult {
@@ -141,10 +141,10 @@ mutation {
       }
     }
   }
-  startTomTomScoreSchedule: startSchedule(scheduleSelector: { 
-    scheduleName: "tomtom_score_schedule", 
-    repositoryName: "__repository__", 
-    repositoryLocationName: "anomstack_code" 
+  startTomTomScoreSchedule: startSchedule(scheduleSelector: {
+    scheduleName: "tomtom_score_schedule",
+    repositoryName: "__repository__",
+    repositoryLocationName: "anomstack_code"
   }) {
     __typename
     ... on ScheduleStateResult {
@@ -154,10 +154,10 @@ mutation {
       }
     }
   }
-  startTomTomTrainSchedule: startSchedule(scheduleSelector: { 
-    scheduleName: "tomtom_train_schedule", 
-    repositoryName: "__repository__", 
-    repositoryLocationName: "anomstack_code" 
+  startTomTomTrainSchedule: startSchedule(scheduleSelector: {
+    scheduleName: "tomtom_train_schedule",
+    repositoryName: "__repository__",
+    repositoryLocationName: "anomstack_code"
   }) {
     __typename
     ... on ScheduleStateResult {
@@ -169,10 +169,10 @@ mutation {
   }
 
   # EirGrid
-  startEirGridAlertsSchedule: startSchedule(scheduleSelector: { 
-    scheduleName: "eirgrid_alerts_schedule", 
-    repositoryName: "__repository__", 
-    repositoryLocationName: "anomstack_code" 
+  startEirGridAlertsSchedule: startSchedule(scheduleSelector: {
+    scheduleName: "eirgrid_alerts_schedule",
+    repositoryName: "__repository__",
+    repositoryLocationName: "anomstack_code"
   }) {
     __typename
     ... on ScheduleStateResult {
@@ -182,10 +182,10 @@ mutation {
       }
     }
   }
-  startEirGridChangeSchedule: startSchedule(scheduleSelector: { 
-    scheduleName: "eirgrid_change_schedule", 
-    repositoryName: "__repository__", 
-    repositoryLocationName: "anomstack_code" 
+  startEirGridChangeSchedule: startSchedule(scheduleSelector: {
+    scheduleName: "eirgrid_change_schedule",
+    repositoryName: "__repository__",
+    repositoryLocationName: "anomstack_code"
   }) {
     __typename
     ... on ScheduleStateResult {
@@ -195,10 +195,10 @@ mutation {
       }
     }
   }
-  startEirGridIngestSchedule: startSchedule(scheduleSelector: { 
-    scheduleName: "eirgrid_ingest_schedule", 
-    repositoryName: "__repository__", 
-    repositoryLocationName: "anomstack_code" 
+  startEirGridIngestSchedule: startSchedule(scheduleSelector: {
+    scheduleName: "eirgrid_ingest_schedule",
+    repositoryName: "__repository__",
+    repositoryLocationName: "anomstack_code"
   }) {
     __typename
     ... on ScheduleStateResult {
@@ -208,10 +208,10 @@ mutation {
       }
     }
   }
-  startEirGridPlotJobSchedule: startSchedule(scheduleSelector: { 
-    scheduleName: "eirgrid_plot_job_schedule", 
-    repositoryName: "__repository__", 
-    repositoryLocationName: "anomstack_code" 
+  startEirGridPlotJobSchedule: startSchedule(scheduleSelector: {
+    scheduleName: "eirgrid_plot_job_schedule",
+    repositoryName: "__repository__",
+    repositoryLocationName: "anomstack_code"
   }) {
     __typename
     ... on ScheduleStateResult {
@@ -221,10 +221,10 @@ mutation {
       }
     }
   }
-  startEirGridScoreSchedule: startSchedule(scheduleSelector: { 
-    scheduleName: "eirgrid_score_schedule", 
-    repositoryName: "__repository__", 
-    repositoryLocationName: "anomstack_code" 
+  startEirGridScoreSchedule: startSchedule(scheduleSelector: {
+    scheduleName: "eirgrid_score_schedule",
+    repositoryName: "__repository__",
+    repositoryLocationName: "anomstack_code"
   }) {
     __typename
     ... on ScheduleStateResult {
@@ -234,10 +234,10 @@ mutation {
       }
     }
   }
-  startEirGridTrainSchedule: startSchedule(scheduleSelector: { 
-    scheduleName: "eirgrid_train_schedule", 
-    repositoryName: "__repository__", 
-    repositoryLocationName: "anomstack_code" 
+  startEirGridTrainSchedule: startSchedule(scheduleSelector: {
+    scheduleName: "eirgrid_train_schedule",
+    repositoryName: "__repository__",
+    repositoryLocationName: "anomstack_code"
   }) {
     __typename
     ... on ScheduleStateResult {
@@ -249,10 +249,10 @@ mutation {
   }
 
   # Netdata
-  startNetdataAlertsSchedule: startSchedule(scheduleSelector: { 
-    scheduleName: "netdata_alerts_schedule", 
-    repositoryName: "__repository__", 
-    repositoryLocationName: "anomstack_code" 
+  startNetdataAlertsSchedule: startSchedule(scheduleSelector: {
+    scheduleName: "netdata_alerts_schedule",
+    repositoryName: "__repository__",
+    repositoryLocationName: "anomstack_code"
   }) {
     __typename
     ... on ScheduleStateResult {
@@ -262,10 +262,10 @@ mutation {
       }
     }
   }
-  startNetdataChangeSchedule: startSchedule(scheduleSelector: { 
-    scheduleName: "netdata_change_schedule", 
-    repositoryName: "__repository__", 
-    repositoryLocationName: "anomstack_code" 
+  startNetdataChangeSchedule: startSchedule(scheduleSelector: {
+    scheduleName: "netdata_change_schedule",
+    repositoryName: "__repository__",
+    repositoryLocationName: "anomstack_code"
   }) {
     __typename
     ... on ScheduleStateResult {
@@ -275,10 +275,10 @@ mutation {
       }
     }
   }
-  startNetdataIngestSchedule: startSchedule(scheduleSelector: { 
-    scheduleName: "netdata_ingest_schedule", 
-    repositoryName: "__repository__", 
-    repositoryLocationName: "anomstack_code" 
+  startNetdataIngestSchedule: startSchedule(scheduleSelector: {
+    scheduleName: "netdata_ingest_schedule",
+    repositoryName: "__repository__",
+    repositoryLocationName: "anomstack_code"
   }) {
     __typename
     ... on ScheduleStateResult {
@@ -288,10 +288,10 @@ mutation {
       }
     }
   }
-  startNetdataPlotJobSchedule: startSchedule(scheduleSelector: { 
-    scheduleName: "netdata_plot_job_schedule", 
-    repositoryName: "__repository__", 
-    repositoryLocationName: "anomstack_code" 
+  startNetdataPlotJobSchedule: startSchedule(scheduleSelector: {
+    scheduleName: "netdata_plot_job_schedule",
+    repositoryName: "__repository__",
+    repositoryLocationName: "anomstack_code"
   }) {
     __typename
     ... on ScheduleStateResult {
@@ -301,10 +301,10 @@ mutation {
       }
     }
   }
-  startNetdataScoreSchedule: startSchedule(scheduleSelector: { 
-    scheduleName: "netdata_score_schedule", 
-    repositoryName: "__repository__", 
-    repositoryLocationName: "anomstack_code" 
+  startNetdataScoreSchedule: startSchedule(scheduleSelector: {
+    scheduleName: "netdata_score_schedule",
+    repositoryName: "__repository__",
+    repositoryLocationName: "anomstack_code"
   }) {
     __typename
     ... on ScheduleStateResult {
@@ -314,10 +314,10 @@ mutation {
       }
     }
   }
-  startNetdataTrainSchedule: startSchedule(scheduleSelector: { 
-    scheduleName: "netdata_train_schedule", 
-    repositoryName: "__repository__", 
-    repositoryLocationName: "anomstack_code" 
+  startNetdataTrainSchedule: startSchedule(scheduleSelector: {
+    scheduleName: "netdata_train_schedule",
+    repositoryName: "__repository__",
+    repositoryLocationName: "anomstack_code"
   }) {
     __typename
     ... on ScheduleStateResult {
@@ -329,10 +329,10 @@ mutation {
   }
 
   # NetdataHTTPCheck
-  startNetdataHTTPCheckAlertsSchedule: startSchedule(scheduleSelector: { 
-    scheduleName: "netdata_httpcheck_alerts_schedule", 
-    repositoryName: "__repository__", 
-    repositoryLocationName: "anomstack_code" 
+  startNetdataHTTPCheckAlertsSchedule: startSchedule(scheduleSelector: {
+    scheduleName: "netdata_httpcheck_alerts_schedule",
+    repositoryName: "__repository__",
+    repositoryLocationName: "anomstack_code"
   }) {
     __typename
     ... on ScheduleStateResult {
@@ -342,10 +342,10 @@ mutation {
       }
     }
   }
-  startNetdataHTTPCheckChangeSchedule: startSchedule(scheduleSelector: { 
-    scheduleName: "netdata_httpcheck_change_schedule", 
-    repositoryName: "__repository__", 
-    repositoryLocationName: "anomstack_code" 
+  startNetdataHTTPCheckChangeSchedule: startSchedule(scheduleSelector: {
+    scheduleName: "netdata_httpcheck_change_schedule",
+    repositoryName: "__repository__",
+    repositoryLocationName: "anomstack_code"
   }) {
     __typename
     ... on ScheduleStateResult {
@@ -355,10 +355,10 @@ mutation {
       }
     }
   }
-  startNetdataHTTPCheckIngestSchedule: startSchedule(scheduleSelector: { 
-    scheduleName: "netdata_httpcheck_ingest_schedule", 
-    repositoryName: "__repository__", 
-    repositoryLocationName: "anomstack_code" 
+  startNetdataHTTPCheckIngestSchedule: startSchedule(scheduleSelector: {
+    scheduleName: "netdata_httpcheck_ingest_schedule",
+    repositoryName: "__repository__",
+    repositoryLocationName: "anomstack_code"
   }) {
     __typename
     ... on ScheduleStateResult {
@@ -368,10 +368,10 @@ mutation {
       }
     }
   }
-  startNetdataHTTPCheckPlotJobSchedule: startSchedule(scheduleSelector: { 
-    scheduleName: "netdata_httpcheck_plot_job_schedule", 
-    repositoryName: "__repository__", 
-    repositoryLocationName: "anomstack_code" 
+  startNetdataHTTPCheckPlotJobSchedule: startSchedule(scheduleSelector: {
+    scheduleName: "netdata_httpcheck_plot_job_schedule",
+    repositoryName: "__repository__",
+    repositoryLocationName: "anomstack_code"
   }) {
     __typename
     ... on ScheduleStateResult {
@@ -381,10 +381,10 @@ mutation {
       }
     }
   }
-  startNetdataHTTPCheckScoreSchedule: startSchedule(scheduleSelector: { 
-    scheduleName: "netdata_httpcheck_score_schedule", 
-    repositoryName: "__repository__", 
-    repositoryLocationName: "anomstack_code" 
+  startNetdataHTTPCheckScoreSchedule: startSchedule(scheduleSelector: {
+    scheduleName: "netdata_httpcheck_score_schedule",
+    repositoryName: "__repository__",
+    repositoryLocationName: "anomstack_code"
   }) {
     __typename
     ... on ScheduleStateResult {
@@ -394,10 +394,10 @@ mutation {
       }
     }
   }
-  startNetdataHTTPCheckTrainSchedule: startSchedule(scheduleSelector: { 
-    scheduleName: "netdata_httpcheck_train_schedule", 
-    repositoryName: "__repository__", 
-    repositoryLocationName: "anomstack_code" 
+  startNetdataHTTPCheckTrainSchedule: startSchedule(scheduleSelector: {
+    scheduleName: "netdata_httpcheck_train_schedule",
+    repositoryName: "__repository__",
+    repositoryLocationName: "anomstack_code"
   }) {
     __typename
     ... on ScheduleStateResult {
@@ -409,10 +409,10 @@ mutation {
   }
 
   # GSOD
-  startGSODAlertsSchedule: startSchedule(scheduleSelector: { 
-    scheduleName: "gsod_alerts_schedule", 
-    repositoryName: "__repository__", 
-    repositoryLocationName: "anomstack_code" 
+  startGSODAlertsSchedule: startSchedule(scheduleSelector: {
+    scheduleName: "gsod_alerts_schedule",
+    repositoryName: "__repository__",
+    repositoryLocationName: "anomstack_code"
   }) {
     __typename
     ... on ScheduleStateResult {
@@ -422,10 +422,10 @@ mutation {
       }
     }
   }
-  startGSODChangeSchedule: startSchedule(scheduleSelector: { 
-    scheduleName: "gsod_change_schedule", 
-    repositoryName: "__repository__", 
-    repositoryLocationName: "anomstack_code" 
+  startGSODChangeSchedule: startSchedule(scheduleSelector: {
+    scheduleName: "gsod_change_schedule",
+    repositoryName: "__repository__",
+    repositoryLocationName: "anomstack_code"
   }) {
     __typename
     ... on ScheduleStateResult {
@@ -435,10 +435,10 @@ mutation {
       }
     }
   }
-  startGSODIngestSchedule: startSchedule(scheduleSelector: { 
-    scheduleName: "gsod_ingest_schedule", 
-    repositoryName: "__repository__", 
-    repositoryLocationName: "anomstack_code" 
+  startGSODIngestSchedule: startSchedule(scheduleSelector: {
+    scheduleName: "gsod_ingest_schedule",
+    repositoryName: "__repository__",
+    repositoryLocationName: "anomstack_code"
   }) {
     __typename
     ... on ScheduleStateResult {
@@ -448,10 +448,10 @@ mutation {
       }
     }
   }
-  startGSODPlotJobSchedule: startSchedule(scheduleSelector: { 
-    scheduleName: "gsod_plot_job_schedule", 
-    repositoryName: "__repository__", 
-    repositoryLocationName: "anomstack_code" 
+  startGSODPlotJobSchedule: startSchedule(scheduleSelector: {
+    scheduleName: "gsod_plot_job_schedule",
+    repositoryName: "__repository__",
+    repositoryLocationName: "anomstack_code"
   }) {
     __typename
     ... on ScheduleStateResult {
@@ -461,10 +461,10 @@ mutation {
       }
     }
   }
-  startGSODScoreSchedule: startSchedule(scheduleSelector: { 
-    scheduleName: "gsod_score_schedule", 
-    repositoryName: "__repository__", 
-    repositoryLocationName: "anomstack_code" 
+  startGSODScoreSchedule: startSchedule(scheduleSelector: {
+    scheduleName: "gsod_score_schedule",
+    repositoryName: "__repository__",
+    repositoryLocationName: "anomstack_code"
   }) {
     __typename
     ... on ScheduleStateResult {
@@ -474,10 +474,10 @@ mutation {
       }
     }
   }
-  startGSODTrainSchedule: startSchedule(scheduleSelector: { 
-    scheduleName: "gsod_train_schedule", 
-    repositoryName: "__repository__", 
-    repositoryLocationName: "anomstack_code" 
+  startGSODTrainSchedule: startSchedule(scheduleSelector: {
+    scheduleName: "gsod_train_schedule",
+    repositoryName: "__repository__",
+    repositoryLocationName: "anomstack_code"
   }) {
     __typename
     ... on ScheduleStateResult {
@@ -489,10 +489,10 @@ mutation {
   }
 
   # Gtrends
-  startGtrendsAlertsSchedule: startSchedule(scheduleSelector: { 
-    scheduleName: "gtrends_alerts_schedule", 
-    repositoryName: "__repository__", 
-    repositoryLocationName: "anomstack_code" 
+  startGtrendsAlertsSchedule: startSchedule(scheduleSelector: {
+    scheduleName: "gtrends_alerts_schedule",
+    repositoryName: "__repository__",
+    repositoryLocationName: "anomstack_code"
   }) {
     __typename
     ... on ScheduleStateResult {
@@ -502,10 +502,10 @@ mutation {
       }
     }
   }
-  startGtrendsChangeSchedule: startSchedule(scheduleSelector: { 
-    scheduleName: "gtrends_change_schedule", 
-    repositoryName: "__repository__", 
-    repositoryLocationName: "anomstack_code" 
+  startGtrendsChangeSchedule: startSchedule(scheduleSelector: {
+    scheduleName: "gtrends_change_schedule",
+    repositoryName: "__repository__",
+    repositoryLocationName: "anomstack_code"
   }) {
     __typename
     ... on ScheduleStateResult {
@@ -515,10 +515,10 @@ mutation {
       }
     }
   }
-  startGtrendsIngestSchedule: startSchedule(scheduleSelector: { 
-    scheduleName: "gtrends_ingest_schedule", 
-    repositoryName: "__repository__", 
-    repositoryLocationName: "anomstack_code" 
+  startGtrendsIngestSchedule: startSchedule(scheduleSelector: {
+    scheduleName: "gtrends_ingest_schedule",
+    repositoryName: "__repository__",
+    repositoryLocationName: "anomstack_code"
   }) {
     __typename
     ... on ScheduleStateResult {
@@ -528,10 +528,10 @@ mutation {
       }
     }
   }
-  startGtrendsPlotJobSchedule: startSchedule(scheduleSelector: { 
-    scheduleName: "gtrends_plot_job_schedule", 
-    repositoryName: "__repository__", 
-    repositoryLocationName: "anomstack_code" 
+  startGtrendsPlotJobSchedule: startSchedule(scheduleSelector: {
+    scheduleName: "gtrends_plot_job_schedule",
+    repositoryName: "__repository__",
+    repositoryLocationName: "anomstack_code"
   }) {
     __typename
     ... on ScheduleStateResult {
@@ -541,10 +541,10 @@ mutation {
       }
     }
   }
-  startGtrendsScoreSchedule: startSchedule(scheduleSelector: { 
-    scheduleName: "gtrends_score_schedule", 
-    repositoryName: "__repository__", 
-    repositoryLocationName: "anomstack_code" 
+  startGtrendsScoreSchedule: startSchedule(scheduleSelector: {
+    scheduleName: "gtrends_score_schedule",
+    repositoryName: "__repository__",
+    repositoryLocationName: "anomstack_code"
   }) {
     __typename
     ... on ScheduleStateResult {
@@ -554,10 +554,10 @@ mutation {
       }
     }
   }
-  startGtrendsTrainSchedule: startSchedule(scheduleSelector: { 
-    scheduleName: "gtrends_train_schedule", 
-    repositoryName: "__repository__", 
-    repositoryLocationName: "anomstack_code" 
+  startGtrendsTrainSchedule: startSchedule(scheduleSelector: {
+    scheduleName: "gtrends_train_schedule",
+    repositoryName: "__repository__",
+    repositoryLocationName: "anomstack_code"
   }) {
     __typename
     ... on ScheduleStateResult {
@@ -569,10 +569,10 @@ mutation {
   }
 
   # YFinance
-  startYFinanceAlertsSchedule: startSchedule(scheduleSelector: { 
-    scheduleName: "yfinance_alerts_schedule", 
-    repositoryName: "__repository__", 
-    repositoryLocationName: "anomstack_code" 
+  startYFinanceAlertsSchedule: startSchedule(scheduleSelector: {
+    scheduleName: "yfinance_alerts_schedule",
+    repositoryName: "__repository__",
+    repositoryLocationName: "anomstack_code"
   }) {
     __typename
     ... on ScheduleStateResult {
@@ -582,10 +582,10 @@ mutation {
       }
     }
   }
-  startYFinanceChangeSchedule: startSchedule(scheduleSelector: { 
-    scheduleName: "yfinance_change_schedule", 
-    repositoryName: "__repository__", 
-    repositoryLocationName: "anomstack_code" 
+  startYFinanceChangeSchedule: startSchedule(scheduleSelector: {
+    scheduleName: "yfinance_change_schedule",
+    repositoryName: "__repository__",
+    repositoryLocationName: "anomstack_code"
   }) {
     __typename
     ... on ScheduleStateResult {
@@ -595,10 +595,10 @@ mutation {
       }
     }
   }
-  startYFinanceIngestSchedule: startSchedule(scheduleSelector: { 
-    scheduleName: "yfinance_ingest_schedule", 
-    repositoryName: "__repository__", 
-    repositoryLocationName: "anomstack_code" 
+  startYFinanceIngestSchedule: startSchedule(scheduleSelector: {
+    scheduleName: "yfinance_ingest_schedule",
+    repositoryName: "__repository__",
+    repositoryLocationName: "anomstack_code"
   }) {
     __typename
     ... on ScheduleStateResult {
@@ -608,10 +608,10 @@ mutation {
       }
     }
   }
-  startYFinancePlotJobSchedule: startSchedule(scheduleSelector: { 
-    scheduleName: "yfinance_plot_job_schedule", 
-    repositoryName: "__repository__", 
-    repositoryLocationName: "anomstack_code" 
+  startYFinancePlotJobSchedule: startSchedule(scheduleSelector: {
+    scheduleName: "yfinance_plot_job_schedule",
+    repositoryName: "__repository__",
+    repositoryLocationName: "anomstack_code"
   }) {
     __typename
     ... on ScheduleStateResult {
@@ -621,10 +621,10 @@ mutation {
       }
     }
   }
-  startYFinanceScoreSchedule: startSchedule(scheduleSelector: { 
-    scheduleName: "yfinance_score_schedule", 
-    repositoryName: "__repository__", 
-    repositoryLocationName: "anomstack_code" 
+  startYFinanceScoreSchedule: startSchedule(scheduleSelector: {
+    scheduleName: "yfinance_score_schedule",
+    repositoryName: "__repository__",
+    repositoryLocationName: "anomstack_code"
   }) {
     __typename
     ... on ScheduleStateResult {
@@ -634,10 +634,10 @@ mutation {
       }
     }
   }
-  startYFinanceTrainSchedule: startSchedule(scheduleSelector: { 
-    scheduleName: "yfinance_train_schedule", 
-    repositoryName: "__repository__", 
-    repositoryLocationName: "anomstack_code" 
+  startYFinanceTrainSchedule: startSchedule(scheduleSelector: {
+    scheduleName: "yfinance_train_schedule",
+    repositoryName: "__repository__",
+    repositoryLocationName: "anomstack_code"
   }) {
     __typename
     ... on ScheduleStateResult {
@@ -649,10 +649,10 @@ mutation {
   }
 
   # Weather
-  startWeatherAlertsSchedule: startSchedule(scheduleSelector: { 
-    scheduleName: "weather_alerts_schedule", 
-    repositoryName: "__repository__", 
-    repositoryLocationName: "anomstack_code" 
+  startWeatherAlertsSchedule: startSchedule(scheduleSelector: {
+    scheduleName: "weather_alerts_schedule",
+    repositoryName: "__repository__",
+    repositoryLocationName: "anomstack_code"
   }) {
     __typename
     ... on ScheduleStateResult {
@@ -662,10 +662,10 @@ mutation {
       }
     }
   }
-  startWeatherChangeSchedule: startSchedule(scheduleSelector: { 
-    scheduleName: "weather_change_schedule", 
-    repositoryName: "__repository__", 
-    repositoryLocationName: "anomstack_code" 
+  startWeatherChangeSchedule: startSchedule(scheduleSelector: {
+    scheduleName: "weather_change_schedule",
+    repositoryName: "__repository__",
+    repositoryLocationName: "anomstack_code"
   }) {
     __typename
     ... on ScheduleStateResult {
@@ -675,10 +675,10 @@ mutation {
       }
     }
   }
-  startWeatherIngestSchedule: startSchedule(scheduleSelector: { 
-    scheduleName: "weather_ingest_schedule", 
-    repositoryName: "__repository__", 
-    repositoryLocationName: "anomstack_code" 
+  startWeatherIngestSchedule: startSchedule(scheduleSelector: {
+    scheduleName: "weather_ingest_schedule",
+    repositoryName: "__repository__",
+    repositoryLocationName: "anomstack_code"
   }) {
     __typename
     ... on ScheduleStateResult {
@@ -688,10 +688,10 @@ mutation {
       }
     }
   }
-  startWeatherPlotJobSchedule: startSchedule(scheduleSelector: { 
-    scheduleName: "weather_plot_job_schedule", 
-    repositoryName: "__repository__", 
-    repositoryLocationName: "anomstack_code" 
+  startWeatherPlotJobSchedule: startSchedule(scheduleSelector: {
+    scheduleName: "weather_plot_job_schedule",
+    repositoryName: "__repository__",
+    repositoryLocationName: "anomstack_code"
   }) {
     __typename
     ... on ScheduleStateResult {
@@ -701,10 +701,10 @@ mutation {
       }
     }
   }
-  startWeatherScoreSchedule: startSchedule(scheduleSelector: { 
-    scheduleName: "weather_score_schedule", 
-    repositoryName: "__repository__", 
-    repositoryLocationName: "anomstack_code" 
+  startWeatherScoreSchedule: startSchedule(scheduleSelector: {
+    scheduleName: "weather_score_schedule",
+    repositoryName: "__repository__",
+    repositoryLocationName: "anomstack_code"
   }) {
     __typename
     ... on ScheduleStateResult {
@@ -714,10 +714,10 @@ mutation {
       }
     }
   }
-  startWeatherTrainSchedule: startSchedule(scheduleSelector: { 
-    scheduleName: "weather_train_schedule", 
-    repositoryName: "__repository__", 
-    repositoryLocationName: "anomstack_code" 
+  startWeatherTrainSchedule: startSchedule(scheduleSelector: {
+    scheduleName: "weather_train_schedule",
+    repositoryName: "__repository__",
+    repositoryLocationName: "anomstack_code"
   }) {
     __typename
     ... on ScheduleStateResult {
@@ -729,10 +729,10 @@ mutation {
   }
 
   # HNTopStoriesScores
-  startHNTopStoriesScoresAlertsSchedule: startSchedule(scheduleSelector: { 
-    scheduleName: "hn_top_stories_scores_alerts_schedule", 
-    repositoryName: "__repository__", 
-    repositoryLocationName: "anomstack_code" 
+  startHNTopStoriesScoresAlertsSchedule: startSchedule(scheduleSelector: {
+    scheduleName: "hn_top_stories_scores_alerts_schedule",
+    repositoryName: "__repository__",
+    repositoryLocationName: "anomstack_code"
   }) {
     __typename
     ... on ScheduleStateResult {
@@ -742,10 +742,10 @@ mutation {
       }
     }
   }
-  startHNTopStoriesScoresChangeSchedule: startSchedule(scheduleSelector: { 
-    scheduleName: "hn_top_stories_scores_change_schedule", 
-    repositoryName: "__repository__", 
-    repositoryLocationName: "anomstack_code" 
+  startHNTopStoriesScoresChangeSchedule: startSchedule(scheduleSelector: {
+    scheduleName: "hn_top_stories_scores_change_schedule",
+    repositoryName: "__repository__",
+    repositoryLocationName: "anomstack_code"
   }) {
     __typename
     ... on ScheduleStateResult {
@@ -755,10 +755,10 @@ mutation {
       }
     }
   }
-  startHNTopStoriesScoresIngestSchedule: startSchedule(scheduleSelector: { 
-    scheduleName: "hn_top_stories_scores_ingest_schedule", 
-    repositoryName: "__repository__", 
-    repositoryLocationName: "anomstack_code" 
+  startHNTopStoriesScoresIngestSchedule: startSchedule(scheduleSelector: {
+    scheduleName: "hn_top_stories_scores_ingest_schedule",
+    repositoryName: "__repository__",
+    repositoryLocationName: "anomstack_code"
   }) {
     __typename
     ... on ScheduleStateResult {
@@ -768,10 +768,10 @@ mutation {
       }
     }
   }
-  startHNTopStoriesScoresPlotJobSchedule: startSchedule(scheduleSelector: { 
-    scheduleName: "hn_top_stories_scores_plot_job_schedule", 
-    repositoryName: "__repository__", 
-    repositoryLocationName: "anomstack_code" 
+  startHNTopStoriesScoresPlotJobSchedule: startSchedule(scheduleSelector: {
+    scheduleName: "hn_top_stories_scores_plot_job_schedule",
+    repositoryName: "__repository__",
+    repositoryLocationName: "anomstack_code"
   }) {
     __typename
     ... on ScheduleStateResult {
@@ -781,10 +781,10 @@ mutation {
       }
     }
   }
-  startHNTopStoriesScoresScoreSchedule: startSchedule(scheduleSelector: { 
-    scheduleName: "hn_top_stories_scores_score_schedule", 
-    repositoryName: "__repository__", 
-    repositoryLocationName: "anomstack_code" 
+  startHNTopStoriesScoresScoreSchedule: startSchedule(scheduleSelector: {
+    scheduleName: "hn_top_stories_scores_score_schedule",
+    repositoryName: "__repository__",
+    repositoryLocationName: "anomstack_code"
   }) {
     __typename
     ... on ScheduleStateResult {
@@ -794,10 +794,10 @@ mutation {
       }
     }
   }
-  startHNTopStoriesScoresTrainSchedule: startSchedule(scheduleSelector: { 
-    scheduleName: "hn_top_stories_scores_train_schedule", 
-    repositoryName: "__repository__", 
-    repositoryLocationName: "anomstack_code" 
+  startHNTopStoriesScoresTrainSchedule: startSchedule(scheduleSelector: {
+    scheduleName: "hn_top_stories_scores_train_schedule",
+    repositoryName: "__repository__",
+    repositoryLocationName: "anomstack_code"
   }) {
     __typename
     ... on ScheduleStateResult {

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -28,6 +28,13 @@ const sidebars = {
       label: 'Deployment',
       items: ['deployment/gcp'],
     },
+    {
+        type: 'category',
+        label: 'GraphQL',
+        items: [
+            'graphql/examples/start_schedule'
+        ],
+      },
   ],
 };
 


### PR DESCRIPTION
This pull request adds documentation and examples for GraphQL to enable multiple jobs in one API call. It includes the following commits:

- Add graphql examples to enable multiple jobs in one api call

- Add GraphQL documentation

- Add GraphQL example to sidebars.js

- Add 'docs' target to Makefile