### PR TITLE
Add metric summary email functionality

### DIFF
--- a/anomstack/alerts/email.py
+++ b/anomstack/alerts/email.py
@@ -82,3 +82,45 @@ def send_email_with_plot(
             server.quit()
 
     logger.info(f"email '{subject}' sent to {to}")
+
+
+def send_email(
+    subject,
+    body,
+) -> None:
+    """
+    Sends an email.
+
+    Args:
+        subject (str): The subject of the email.
+        body (str): The body of the email.
+
+    Returns:
+        None
+    """
+
+    logger = get_dagster_logger()
+
+    sender = os.getenv("ANOMSTACK_ALERT_EMAIL_FROM")
+    password = os.getenv("ANOMSTACK_ALERT_EMAIL_PASSWORD")
+    to = os.getenv("ANOMSTACK_ALERT_EMAIL_TO")
+    host = os.getenv("ANOMSTACK_ALERT_EMAIL_SMTP_HOST")
+    port = os.getenv("ANOMSTACK_ALERT_EMAIL_SMTP_PORT")
+
+    msg = MIMEMultipart()
+    msg["From"] = sender
+    msg["To"] = to
+    msg["Subject"] = subject
+
+    msg.attach(MIMEText(body, "html"))
+
+    context = ssl.create_default_context()
+    with smtplib.SMTP(host, port) as server:
+        server.connect(host, port)
+        server.starttls(context=context)
+        server.login(sender, password)
+        text = msg.as_string()
+        server.sendmail(sender, to, text)
+        server.quit()
+
+    logger.info(f"email '{subject}' sent to {to}")

--- a/anomstack/alerts/send.py
+++ b/anomstack/alerts/send.py
@@ -6,7 +6,7 @@ import pandas as pd
 from dagster import get_dagster_logger
 
 from anomstack.alerts.asciiart import make_alert_message
-from anomstack.alerts.email import send_email_with_plot, send_email
+from anomstack.alerts.email import send_email, send_email_with_plot
 from anomstack.alerts.slack import send_alert_slack
 
 

--- a/anomstack/alerts/send.py
+++ b/anomstack/alerts/send.py
@@ -6,7 +6,7 @@ import pandas as pd
 from dagster import get_dagster_logger
 
 from anomstack.alerts.asciiart import make_alert_message
-from anomstack.alerts.email import send_email_with_plot
+from anomstack.alerts.email import send_email_with_plot, send_email
 from anomstack.alerts.slack import send_alert_slack
 
 
@@ -52,6 +52,39 @@ def send_alert(
             attachment_name=metric_name,
             threshold=threshold,
             score_col=score_col,
+        )
+
+    return df
+
+
+def send_df(
+    title: str,
+    df: pd.DataFrame,
+    alert_methods: str = "email,slack",
+    description: str = "",
+) -> pd.DataFrame:
+    """
+    Sends a df using the specified alert methods.
+
+    Args:
+        title (str): The title of the alert.
+        df (pd.DataFrame): The data to be included in the alert.
+        alert_methods (str, optional): The alert methods to use, separated by commas. Defaults to 'email,slack'.
+        description (str, optional): The description of the alert. Defaults to ''.
+        tags (list, optional): The tags to be included in the alert. Defaults to None.
+
+    Returns:
+        pd.DataFrame: The input DataFrame.
+    """
+    logger = get_dagster_logger()
+    logger.debug(f"alerts to send: \n{df}")
+    message = df.to_html()
+    if "slack" in alert_methods:
+        send_alert_slack(title=title, message=message)
+    if "email" in alert_methods:
+        send_email(
+            subject=title,
+            body=message,
         )
 
     return df

--- a/anomstack/jobs/summary.py
+++ b/anomstack/jobs/summary.py
@@ -1,0 +1,106 @@
+"""
+Generate summary job and schedule.
+"""
+
+import os
+
+import pandas as pd
+from dagster import (
+    MAX_RUNTIME_SECONDS_TAG,
+    DefaultScheduleStatus,
+    JobDefinition,
+    ScheduleDefinition,
+    get_dagster_logger,
+    job,
+    op,
+)
+
+from anomstack.config import specs
+from anomstack.jinja.render import render
+from anomstack.sql.read import read_sql
+from anomstack.alerts.send import send_df
+
+ANOMSTACK_MAX_RUNTIME_SECONDS_TAG = os.getenv("ANOMSTACK_MAX_RUNTIME_SECONDS_TAG", 3600)
+
+
+def build_summary_job(spec: dict) -> JobDefinition:
+    """
+    Build job definitions for summary jobs.
+
+    Args:
+        spec (dict): A dictionary containing the specifications for the summary job.
+
+    Returns:
+        JobDefinition: A job definition for the summary job.
+    """
+
+    if spec.get("disable_summary"):
+
+        @job(
+            name=f'{spec["metric_batch"]}_summary_disabled',
+            tags={MAX_RUNTIME_SECONDS_TAG: ANOMSTACK_MAX_RUNTIME_SECONDS_TAG},
+        )
+        def _dummy_job():
+            @op(name=f'{spec["metric_batch"]}_noop')
+            def noop():
+                pass
+
+            noop()
+
+        return _dummy_job
+
+    logger = get_dagster_logger()
+
+    db = spec["db"]
+    table_key = spec["table_key"]
+
+    @job(
+        name="summary",
+        tags={MAX_RUNTIME_SECONDS_TAG: ANOMSTACK_MAX_RUNTIME_SECONDS_TAG},
+    )
+    def _job():
+        """
+        Get data for summary.
+        """
+
+        @op(name="get_summary")
+        def get_summary() -> pd.DataFrame:
+            """
+            Get data for summary.
+
+            Returns:
+                pd.DataFrame: A pandas DataFrame containing the data for summary.
+            """
+            df_summary = read_sql(render("summary_sql", spec), db)
+
+            return df_summary
+
+        @op(name="send_summary")
+        def send_summary(df_summary) -> pd.DataFrame:
+            """ """
+
+            logger.info(f"sending {len(df_summary)} summary to {db} {table_key}")
+            send_df(
+                title="Anomstack Summary",
+                df=df_summary,
+            )
+
+            return df_summary
+
+        send_summary(get_summary())
+
+    return _job
+
+
+# Build summary job and schedule.
+spec = specs[list(specs.keys())[0]]
+spec["name"] = "summary"
+summary_job = build_summary_job(spec)
+summary_jobs = [summary_job]
+summary_default_schedule_status = DefaultScheduleStatus.RUNNING
+summary_schedule = ScheduleDefinition(
+    job=summary_job,
+    cron_schedule=spec["summary_cron_schedule"],
+    default_status=summary_default_schedule_status,
+)
+summary_schedules = [summary_schedule]

--- a/anomstack/jobs/summary.py
+++ b/anomstack/jobs/summary.py
@@ -15,10 +15,10 @@ from dagster import (
     op,
 )
 
+from anomstack.alerts.send import send_df
 from anomstack.config import specs
 from anomstack.jinja.render import render
 from anomstack.sql.read import read_sql
-from anomstack.alerts.send import send_df
 
 ANOMSTACK_MAX_RUNTIME_SECONDS_TAG = os.getenv("ANOMSTACK_MAX_RUNTIME_SECONDS_TAG", 3600)
 

--- a/anomstack/main.py
+++ b/anomstack/main.py
@@ -11,6 +11,7 @@ from anomstack.jobs.llmalert import llmalert_jobs, llmalert_schedules
 from anomstack.jobs.plot import plot_jobs, plot_schedules
 from anomstack.jobs.score import score_jobs, score_schedules
 from anomstack.jobs.train import train_jobs, train_schedules
+from anomstack.jobs.summary import summary_jobs, summary_schedules
 
 # from anomstack.sensors.failure import email_on_run_failure
 
@@ -22,6 +23,7 @@ jobs = (
     + llmalert_jobs
     + plot_jobs
     + change_jobs
+    + summary_jobs
 )
 # sensors = [email_on_run_failure]
 schedules = (
@@ -32,6 +34,7 @@ schedules = (
     + llmalert_schedules
     + plot_schedules
     + change_schedules
+    + summary_schedules
 )
 
 defs = Definitions(

--- a/anomstack/main.py
+++ b/anomstack/main.py
@@ -10,8 +10,8 @@ from anomstack.jobs.ingest import ingest_jobs, ingest_schedules
 from anomstack.jobs.llmalert import llmalert_jobs, llmalert_schedules
 from anomstack.jobs.plot import plot_jobs, plot_schedules
 from anomstack.jobs.score import score_jobs, score_schedules
-from anomstack.jobs.train import train_jobs, train_schedules
 from anomstack.jobs.summary import summary_jobs, summary_schedules
+from anomstack.jobs.train import train_jobs, train_schedules
 
 # from anomstack.sensors.failure import email_on_run_failure
 

--- a/metrics/defaults/defaults.yaml
+++ b/metrics/defaults/defaults.yaml
@@ -24,6 +24,7 @@ alert_max_n: 250 # max n to include and plot in an alert.
 change_max_n: 250 # max n to include in change detection.
 alert_metric_timestamp_max_days_ago: 45 # don't alert on metrics older than this.
 change_metric_timestamp_max_days_ago: 45 # don't all metrics older than this into change detection.
+summary_metric_timestamp_max_days_ago: 1 # number of days to look over for summary email.
 alert_recent_n: 1 # only alert on recent n so as to avoid continually alerting.
 alert_smooth_n: 3 # smooth anomaly score over rolling n to avoid being too trigger happy.
 alert_snooze_n: 3 # snooze alerts for n periods after an alert.
@@ -58,6 +59,7 @@ llmalert_cron_schedule: "*/5 * * * *" # cron schedule for llmalerting jobs
 llmalert_default_schedule_status: 'STOPPED' # default schedule status for llmalert jobs (RUNNING or STOPPED)
 plot_cron_schedule: "*/5 * * * *" # cron schedule for plot jobs
 plot_default_schedule_status: 'STOPPED' # default schedule status for plot jobs (RUNNING or STOPPED)
+summary_cron_schedule: "0 9 * * *" # cron schedule for summary job
 # default templated train sql
 train_sql: >
   {% include "./defaults/sql/train.sql" %}
@@ -75,6 +77,9 @@ plot_sql: >
 # default templated dashboard sql
 dashboard_sql: >
   {% include "./defaults/sql/dashboard.sql" %}
+# default templated summary sql
+summary_sql: >
+  {% include "./defaults/sql/summary.sql" %}
 disable_ingest: False # if you want to disable ingest job for some reason.
 disable_train: False # if you want to disable train job for some reason.
 disable_score: False # if you want to disable score job for some reason.
@@ -82,5 +87,6 @@ disable_alert: False # if you want to disable alert job for some reason.
 disable_change: False # if you want to disable change detection job for some reason.
 disable_llmalert: True # if you want to disable llmalert job for some reason.
 disable_plot: False # if you want to disable plot job for some reason.
+disable_summary: False # if you want to disable summary job for some reason.
 prompt_fn: >
   {% include "./defaults/python/prompt.py" %}

--- a/metrics/defaults/sql/summary.sql
+++ b/metrics/defaults/sql/summary.sql
@@ -1,13 +1,13 @@
-select 
+select
   metric_batch,
   metric_name,
   max(metric_timestamp) as metric_timestamp_max,
   sum(if(metric_type='metric',1,0)) as n_metric,
   sum(if(metric_type='score',1,0)) as n_score,
-  sum(if(metric_type='alert',1,0)) as n_alert, 
-from 
-  {{ table_key }} 
-where 
+  sum(if(metric_type='alert',1,0)) as n_alert,
+from
+  {{ table_key }}
+where
   -- limit to the last {{ summary_metric_timestamp_max_days_ago }} days
   cast(metric_timestamp as datetime) >= CURRENT_DATE - INTERVAL '{{ summary_metric_timestamp_max_days_ago }}' DAY
 group by 1,2

--- a/metrics/defaults/sql/summary.sql
+++ b/metrics/defaults/sql/summary.sql
@@ -1,0 +1,14 @@
+select 
+  metric_batch,
+  metric_name,
+  max(metric_timestamp) as metric_timestamp_max,
+  sum(if(metric_type='metric',1,0)) as n_metric,
+  sum(if(metric_type='score',1,0)) as n_score,
+  sum(if(metric_type='alert',1,0)) as n_alert, 
+from 
+  {{ table_key }} 
+where 
+  -- limit to the last {{ summary_metric_timestamp_max_days_ago }} days
+  cast(metric_timestamp as datetime) >= CURRENT_DATE - INTERVAL '{{ summary_metric_timestamp_max_days_ago }}' DAY
+group by 1,2
+order by 6 desc

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -8,19 +8,19 @@ logger = logging.getLogger(__name__)
 
 
 def test_jobs_len():
-    assert len(jobs) == 126
+    assert len(jobs) == 127
 
 
 def test_jobs_len_ingest():
-    assert len(ingest_jobs) == len(jobs) / 7
+    assert len(ingest_jobs) == (len(jobs)-1) / 7
 
 
 def test_schedules_len():
-    assert len(schedules) == 126
+    assert len(schedules) == 127
 
 
 def test_schedules_len_ingest():
-    assert len(ingest_schedules) == len(schedules) / 7
+    assert len(ingest_schedules) == (len(schedules)-1) / 7
 
 
 def test_jobs_schedules_len_match():


### PR DESCRIPTION
Sends a daily summary of metrics, scores and alerts.

This commit adds a new function called `send_df` to the `send.py` file in the `anomstack.alerts` module. The `send_df` function allows sending alerts with a DataFrame using the specified alert methods, such as email and Slack. The function takes a title, a DataFrame, and optional parameters like alert methods and description. It converts the DataFrame to HTML and sends the alert using the specified methods.