### PR TITLE
include model tags as groundwork for suporting multiple models

### DIFF
--- a/anomstack/external/aws/s3.py
+++ b/anomstack/external/aws/s3.py
@@ -46,26 +46,26 @@ def get_s3_client() -> boto3.client:
 
 
 def save_models_s3(
-    models: List[Tuple[str, BaseDetector]], model_path: str, metric_batch
-) -> List[Tuple[str, BaseDetector]]:
+    models: List[Tuple[str, BaseDetector, str]], model_path: str, metric_batch
+) -> List[Tuple[str, BaseDetector, str]]:
     """
     Save models to S3.
 
     Args:
-        models (List[Tuple[str, BaseDetector]]): The models to be saved.
+        models (List[Tuple[str, BaseDetector, str]]): The models to be saved.
         model_path (str): The S3 model path.
         metric_batch: The metric batch.
 
     Returns:
-        List[Tuple[str, BaseDetector]]: The list of saved models.
+        List[Tuple[str, BaseDetector, str]]: The list of saved models.
     """
     logger = get_dagster_logger()
     model_path_bucket, model_path_prefix = split_model_path(model_path)
 
     s3_client = get_s3_client()
 
-    for metric, model in models:
-        model_name = f"{metric}.pkl"
+    for metric, model, model_tag in models:
+        model_name = f"{metric}_{model_tag}.pkl"
         logger.info(f"saving {model_name} to {model_path}")
 
         model_byte_stream = pickle.dumps(model)

--- a/anomstack/external/gcp/gcs.py
+++ b/anomstack/external/gcp/gcs.py
@@ -50,17 +50,17 @@ def get_credentials():
         return None
 
 
-def save_models_gcs(models, model_path, metric_batch) -> List[Tuple[str, BaseDetector]]:
+def save_models_gcs(models, model_path, metric_batch) -> List[Tuple[str, BaseDetector, str]]:
     """
     Save trained models to gcs bucket.
 
     Args:
-        models (List[Tuple[str, BaseDetector]]): The list of models to save.
+        models (List[Tuple[str, BaseDetector, str]]): The list of models to save.
         model_path (str): The model path.
         metric_batch (str): The metric batch.
 
     Returns:
-        List[Tuple[str, BaseDetector]]: The list of saved models.
+        List[Tuple[str, BaseDetector, str]]: The list of saved models.
     """
     logger = get_dagster_logger()
 
@@ -70,8 +70,8 @@ def save_models_gcs(models, model_path, metric_batch) -> List[Tuple[str, BaseDet
     storage_client = storage.Client(credentials=credentials)
     bucket = storage_client.get_bucket(model_path_bucket)
 
-    for metric, model in models:
-        model_name = f"{metric}.pkl"
+    for metric, model, model_tag in models:
+        model_name = f"{metric}_{model_tag}.pkl"
         logger.info(f"saving {model_name} to {model_path}")
 
         blob = bucket.blob(f"{model_path_prefix}/{metric_batch}/{model_name}")

--- a/anomstack/io/save.py
+++ b/anomstack/io/save.py
@@ -13,8 +13,8 @@ from anomstack.external.gcp.gcs import save_models_gcs
 
 
 def save_models_local(
-    models: List[Tuple[str, BaseDetector]], model_path: str, metric_batch: str
-) -> List[Tuple[str, BaseDetector]]:
+    models: List[Tuple[str, BaseDetector, str]], model_path: str, metric_batch: str
+) -> List[Tuple[str, BaseDetector, str]]:
     """
     Save trained models locally.
 
@@ -32,16 +32,16 @@ def save_models_local(
     if not os.path.exists(f"{model_path}/{metric_batch}"):
         os.makedirs(f"{model_path}/{metric_batch}")
 
-    for metric_name, model in models:
-        with open(f"{model_path}/{metric_batch}/{metric_name}.pkl", "wb") as f:
+    for metric_name, model, model_tag in models:
+        with open(f"{model_path}/{metric_batch}/{metric_name}_{model_tag}.pkl", "wb") as f:
             pickle.dump(model, f)
 
     return models
 
 
 def save_models(
-    models: List[Tuple[str, BaseDetector]], model_path: str, metric_batch: str
-) -> List[Tuple[str, BaseDetector]]:
+    models: List[Tuple[str, BaseDetector, str]], model_path: str, metric_batch: str
+) -> List[Tuple[str, BaseDetector, str]]:
     """
     Save trained models.
 

--- a/anomstack/jobs/train.py
+++ b/anomstack/jobs/train.py
@@ -58,6 +58,7 @@ def build_train_job(spec: dict) -> JobDefinition:
     model_path = spec["model_path"]
     preprocess_params = spec["preprocess_params"]
     model_name = spec["model_config"]["model_name"]
+    model_tag = spec["model_config"].get("model_tag", "")
     model_params = spec["model_config"]["model_params"]
 
     @job(
@@ -85,7 +86,7 @@ def build_train_job(spec: dict) -> JobDefinition:
             return df
 
         @op(name=f"{metric_batch}_train_models")
-        def train(df) -> List[Tuple[str, BaseDetector]]:
+        def train(df) -> List[Tuple[str, BaseDetector, str]]:
             """
             Train models.
 
@@ -94,7 +95,7 @@ def build_train_job(spec: dict) -> JobDefinition:
                     training.
 
             Returns:
-                List[Tuple[str, BaseDetector]]: A list of tuples containing
+                List[Tuple[str, BaseDetector, str]]: A list of tuples containing
                     the metric name and the trained model.
             """
 
@@ -130,9 +131,9 @@ def build_train_job(spec: dict) -> JobDefinition:
                             )
                         )
                         model = train_model(
-                            X, metric_name, model_name, model_params
+                            X, metric_name, model_name, model_params, model_tag
                         )
-                        models.append((metric_name, model))
+                        models.append((metric_name, model, model_tag))
                     else:
                         logger.info(
                             f"no data for {metric_name} in {metric_batch} train job."
@@ -141,16 +142,16 @@ def build_train_job(spec: dict) -> JobDefinition:
                 return models
 
         @op(name=f"{metric_batch}_save_model")
-        def save(models) -> List[Tuple[str, BaseDetector]]:
+        def save(models) -> List[Tuple[str, BaseDetector, str]]:
             """
             Save trained models.
 
             Args:
-                models (List[Tuple[str, BaseDetector]]): A list of tuples
+                models (List[Tuple[str, BaseDetector, str]]): A list of tuples
                     containing the metric name and the trained model.
 
             Returns:
-                List[Tuple[str, BaseDetector]]: A list of tuples containing
+                List[Tuple[str, BaseDetector, str]]: A list of tuples containing
                     the metric name and the trained model.
             """
 

--- a/anomstack/ml/train.py
+++ b/anomstack/ml/train.py
@@ -11,7 +11,11 @@ from pyod.models.base import BaseDetector
 
 
 def train_model(
-    X: pd.DataFrame, metric: str, model_name: str, model_params: dict
+    X: pd.DataFrame,
+    metric: str,
+    model_name: str,
+    model_params: dict,
+    model_tag: str = ""
 ) -> BaseDetector:
     """
     Train a model.
@@ -21,6 +25,7 @@ def train_model(
         metric (str): The metric used for training the model.
         model_name (str): The name of the model to be trained.
         model_params (dict): The parameters for the model.
+        model_tag (str): The tag associated with the model.
 
     Returns:
         BaseDetector: The trained model.
@@ -29,7 +34,8 @@ def train_model(
     logger = get_dagster_logger()
 
     model_class = getattr(
-        importlib.import_module(f"pyod.models.{model_name.lower()}"), model_name
+        importlib.import_module(f"pyod.models.{model_name.lower()}"),
+        model_name
     )
     model = model_class(**model_params)
 
@@ -39,7 +45,8 @@ def train_model(
     train_time = time_end_train - time_start_train
     logger.debug(
         (
-            f"trained model ({model_name}({model_params})) for {metric} "
+            f"trained model ({model_name}({model_params})) "
+            f"(tag={model_tag}) for {metric} "
             f"(n={len(X)}, train_time={round(train_time, 2)} secs)"
         )
     )

--- a/metrics/defaults/defaults.yaml
+++ b/metrics/defaults/defaults.yaml
@@ -7,6 +7,7 @@ model_path: "local://./models" # path to where models are to be stored.
 # model configs to pass to PyOD, model_params are passed to the model constructor.
 model_config:
   model_name: 'PCA'
+  model_tag: 'pca_default'
   model_params:
     contamination: 0.01
 # metric_tags is a map of metric key value tags to metric names


### PR DESCRIPTION
This pull request introduces changes to the model saving and training processes across multiple storage backends (S3, GCS, and local) to include a `model_tag` attribute. This ensures that models are saved with a more descriptive filename that includes the tag.

### Model Saving Enhancements:
* [`anomstack/external/aws/s3.py`](diffhunk://#diff-74a4a8bc8e38f90c74853f187167d6ee60e03d57d6456798ac807668c670b285L49-R68): Updated `save_models_s3` function to include `model_tag` in the model filenames and the list of models to be saved.
* [`anomstack/external/gcp/gcs.py`](diffhunk://#diff-d8e6a65a95cbb8981a51c1bbcc8287eeeeed2d8f997ee90e3626e0dfd4cc64c8L53-R63): Updated `save_models_gcs` function to include `model_tag` in the model filenames and the list of models to be saved. [[1]](diffhunk://#diff-d8e6a65a95cbb8981a51c1bbcc8287eeeeed2d8f997ee90e3626e0dfd4cc64c8L53-R63) [[2]](diffhunk://#diff-d8e6a65a95cbb8981a51c1bbcc8287eeeeed2d8f997ee90e3626e0dfd4cc64c8L73-R74)
* [`anomstack/io/save.py`](diffhunk://#diff-541989ca5417356cdefd658dae095bc86356a70c5a9b71a77d23ec1ac3ac6939L16-R17): Updated `save_models_local` function to include `model_tag` in the model filenames and the list of models to be saved. [[1]](diffhunk://#diff-541989ca5417356cdefd658dae095bc86356a70c5a9b71a77d23ec1ac3ac6939L16-R17) [[2]](diffhunk://#diff-541989ca5417356cdefd658dae095bc86356a70c5a9b71a77d23ec1ac3ac6939L35-R44)

### Model Training Enhancements:
* [`anomstack/jobs/train.py`](diffhunk://#diff-ee9674bc9f389120548cc7379bae9497e0500b054c8c89a59b9810cb6a66f930R61): Added `model_tag` to the training process and updated the `train` function to return models with the `model_tag`. [[1]](diffhunk://#diff-ee9674bc9f389120548cc7379bae9497e0500b054c8c89a59b9810cb6a66f930R61) [[2]](diffhunk://#diff-ee9674bc9f389120548cc7379bae9497e0500b054c8c89a59b9810cb6a66f930L88-R89) [[3]](diffhunk://#diff-ee9674bc9f389120548cc7379bae9497e0500b054c8c89a59b9810cb6a66f930L97-R98) [[4]](diffhunk://#diff-ee9674bc9f389120548cc7379bae9497e0500b054c8c89a59b9810cb6a66f930L133-R136) [[5]](diffhunk://#diff-ee9674bc9f389120548cc7379bae9497e0500b054c8c89a59b9810cb6a66f930L144-R154)
* [`anomstack/ml/train.py`](diffhunk://#diff-be9f1d5ee20b0e1d1ac1c977fb1cdb5e77e0fbc087905893a0ed0062b68f5377L14-R18): Modified `train_model` function to accept and log the `model_tag`. [[1]](diffhunk://#diff-be9f1d5ee20b0e1d1ac1c977fb1cdb5e77e0fbc087905893a0ed0062b68f5377L14-R18) [[2]](diffhunk://#diff-be9f1d5ee20b0e1d1ac1c977fb1cdb5e77e0fbc087905893a0ed0062b68f5377R28) [[3]](diffhunk://#diff-be9f1d5ee20b0e1d1ac1c977fb1cdb5e77e0fbc087905893a0ed0062b68f5377L32-R38) [[4]](diffhunk://#diff-be9f1d5ee20b0e1d1ac1c977fb1cdb5e77e0fbc087905893a0ed0062b68f5377L42-R49)

### Configuration Updates:
* [`metrics/defaults/defaults.yaml`](diffhunk://#diff-87b1ac24a54e3a83a9a0c5caddafbc2b2e4c8df4cee00ebfe10c73968112b2f7R10): Added `model_tag` to the default model configuration.