### PR TITLE
Add model tag for scores

### DIFF
--- a/anomstack/external/aws/s3.py
+++ b/anomstack/external/aws/s3.py
@@ -78,7 +78,9 @@ def save_models_s3(
     return models
 
 
-def load_model_s3(metric_name: str, model_path: str, metric_batch) -> BaseDetector:
+def load_model_s3(
+    metric_name: str, model_path: str, metric_batch, model_tag: str
+) -> BaseDetector:
     """
     Load a model from S3.
 
@@ -86,6 +88,7 @@ def load_model_s3(metric_name: str, model_path: str, metric_batch) -> BaseDetect
         metric_name (str): The name of the metric.
         model_path (str): The S3 model path.
         metric_batch: The metric batch.
+        model_tag (str): The tag of the model.
 
     Returns:
         BaseDetector: The loaded model.
@@ -93,13 +96,14 @@ def load_model_s3(metric_name: str, model_path: str, metric_batch) -> BaseDetect
     logger = get_dagster_logger()
     model_path_bucket, model_path_prefix = split_model_path(model_path)
 
-    model_name = f"{metric_name}.pkl"
+    model_name = f"{metric_name}_{model_tag}.pkl"
     logger.info(f"loading {model_name} from {model_path}")
 
     s3_client = get_s3_client()
 
     model_obj = s3_client.get_object(
-        Bucket=model_path_bucket, Key=f"{model_path_prefix}/{metric_batch}/{model_name}"
+        Bucket=model_path_bucket,
+        Key=f"{model_path_prefix}/{metric_batch}/{model_name}"
     )
 
     model_byte_stream = model_obj["Body"].read()

--- a/anomstack/external/gcp/gcs.py
+++ b/anomstack/external/gcp/gcs.py
@@ -50,7 +50,9 @@ def get_credentials():
         return None
 
 
-def save_models_gcs(models, model_path, metric_batch) -> List[Tuple[str, BaseDetector, str]]:
+def save_models_gcs(
+    models, model_path, metric_batch
+) -> List[Tuple[str, BaseDetector, str]]:
     """
     Save trained models to gcs bucket.
 
@@ -82,7 +84,9 @@ def save_models_gcs(models, model_path, metric_batch) -> List[Tuple[str, BaseDet
     return models
 
 
-def load_model_gcs(metric_name, model_path, metric_batch) -> BaseDetector:
+def load_model_gcs(
+    metric_name: str, model_path: str, metric_batch: str, model_tag: str
+) -> BaseDetector:
     """
     Load model.
 
@@ -102,7 +106,7 @@ def load_model_gcs(metric_name, model_path, metric_batch) -> BaseDetector:
     storage_client = storage.Client(credentials=credentials)
     bucket = storage_client.get_bucket(model_path_bucket)
 
-    model_name = f"{metric_name}.pkl"
+    model_name = f"{metric_name}_{model_tag}.pkl"
     logger.info(f"loading {model_name} from {model_path}")
 
     blob = bucket.blob(f"{model_path_prefix}/{metric_batch}/{model_name}")

--- a/anomstack/io/load.py
+++ b/anomstack/io/load.py
@@ -3,7 +3,6 @@ Some helper functions for loading models.
 """
 
 import pickle
-from turtle import mode
 
 from pyod.models.base import BaseDetector
 

--- a/anomstack/io/load.py
+++ b/anomstack/io/load.py
@@ -3,6 +3,7 @@ Some helper functions for loading models.
 """
 
 import pickle
+from turtle import mode
 
 from pyod.models.base import BaseDetector
 
@@ -10,7 +11,9 @@ from anomstack.external.aws.s3 import load_model_s3
 from anomstack.external.gcp.gcs import load_model_gcs
 
 
-def load_model(metric_name: str, model_path: str, metric_batch: str) -> BaseDetector:
+def load_model(
+    metric_name: str, model_path: str, metric_batch: str, model_tag: str
+) -> BaseDetector:
     """
     Load model.
 
@@ -18,6 +21,7 @@ def load_model(metric_name: str, model_path: str, metric_batch: str) -> BaseDete
         metric_name (str): The name of the metric.
         model_path (str): The path to the model.
         metric_batch (str): The batch of the metric.
+        model_tag (str): The tag of the model.
 
     Returns:
         BaseDetector: The loaded model.
@@ -27,11 +31,17 @@ def load_model(metric_name: str, model_path: str, metric_batch: str) -> BaseDete
     """
 
     if model_path.startswith("gs://"):
-        model = load_model_gcs(metric_name, model_path, metric_batch)
+        model = load_model_gcs(
+            metric_name, model_path, metric_batch, model_tag
+        )
     elif model_path.startswith("s3://"):
-        model = load_model_s3(metric_name, model_path, metric_batch)
+        model = load_model_s3(
+            metric_name, model_path, metric_batch, model_tag
+        )
     elif model_path.startswith("local://"):
-        model = load_model_local(metric_name, model_path, metric_batch)
+        model = load_model_local(
+            metric_name, model_path, metric_batch, model_tag
+        )
     else:
         raise ValueError(f"model_path {model_path} not supported")
 
@@ -39,7 +49,7 @@ def load_model(metric_name: str, model_path: str, metric_batch: str) -> BaseDete
 
 
 def load_model_local(
-    metric_name: str, model_path: str, metric_batch: str
+    metric_name: str, model_path: str, metric_batch: str, model_tag: str
 ) -> BaseDetector:
     """
     Load model locally.
@@ -48,6 +58,7 @@ def load_model_local(
         metric_name (str): The name of the metric.
         model_path (str): The path to the model.
         metric_batch (str): The batch of the metric.
+        model_tag (str): The tag of the model.
 
     Returns:
         BaseDetector: The loaded model.
@@ -55,7 +66,7 @@ def load_model_local(
 
     model_path = model_path.replace("local://", "")
 
-    with open(f"{model_path}/{metric_batch}/{metric_name}.pkl", "rb") as f:
+    with open(f"{model_path}/{metric_batch}/{metric_name}_{model_tag}.pkl", "rb") as f:
         model = pickle.load(f)
 
     return model

--- a/anomstack/io/save.py
+++ b/anomstack/io/save.py
@@ -13,7 +13,9 @@ from anomstack.external.gcp.gcs import save_models_gcs
 
 
 def save_models_local(
-    models: List[Tuple[str, BaseDetector, str]], model_path: str, metric_batch: str
+    models: List[Tuple[str, BaseDetector, str]],
+    model_path: str,
+    metric_batch: str
 ) -> List[Tuple[str, BaseDetector, str]]:
     """
     Save trained models locally.
@@ -33,14 +35,19 @@ def save_models_local(
         os.makedirs(f"{model_path}/{metric_batch}")
 
     for metric_name, model, model_tag in models:
-        with open(f"{model_path}/{metric_batch}/{metric_name}_{model_tag}.pkl", "wb") as f:
+        file_path = (
+            f"{model_path}/{metric_batch}/{metric_name}_{model_tag}.pkl"
+        )
+        with open(file_path, "wb") as f:
             pickle.dump(model, f)
 
     return models
 
 
 def save_models(
-    models: List[Tuple[str, BaseDetector, str]], model_path: str, metric_batch: str
+    models: List[Tuple[str, BaseDetector, str]],
+    model_path: str,
+    metric_batch: str
 ) -> List[Tuple[str, BaseDetector, str]]:
     """
     Save trained models.

--- a/anomstack/jobs/score.py
+++ b/anomstack/jobs/score.py
@@ -58,6 +58,7 @@ def build_score_job(spec: dict) -> JobDefinition:
 
     metric_batch = spec["metric_batch"]
     model_path = spec["model_path"]
+    model_tag = spec["model_config"].get("model_tag", "")
     table_key = spec["table_key"]
     db = spec["db"]
     preprocess_params = spec["preprocess_params"]
@@ -111,7 +112,7 @@ def build_score_job(spec: dict) -> JobDefinition:
 
                 # try load model and catch google.api_core.exceptions.NotFound
                 try:
-                    model = load_model(metric_name, model_path, metric_batch)
+                    model = load_model(metric_name, model_path, metric_batch, model_tag)
                 except NotFound as e:
                     logger.warning(e)
                     logger.warning(


### PR DESCRIPTION
This pull request introduces changes to support loading models with an additional `model_tag` parameter across various storage backends (S3, GCS, and local). The main changes include updating function signatures and modifying how model file names are constructed.

### Support for `model_tag` in model loading and saving:

* [`anomstack/external/aws/s3.py`](diffhunk://#diff-74a4a8bc8e38f90c74853f187167d6ee60e03d57d6456798ac807668c670b285L81-R106): Updated `load_model_s3` function to include `model_tag` parameter and modified model file naming to incorporate the tag.
* [`anomstack/external/gcp/gcs.py`](diffhunk://#diff-d8e6a65a95cbb8981a51c1bbcc8287eeeeed2d8f997ee90e3626e0dfd4cc64c8L85-R89): Updated `load_model_gcs` function to include `model_tag` parameter and modified model file naming to incorporate the tag. [[1]](diffhunk://#diff-d8e6a65a95cbb8981a51c1bbcc8287eeeeed2d8f997ee90e3626e0dfd4cc64c8L85-R89) [[2]](diffhunk://#diff-d8e6a65a95cbb8981a51c1bbcc8287eeeeed2d8f997ee90e3626e0dfd4cc64c8L105-R109)
* [`anomstack/io/load.py`](diffhunk://#diff-a9c13f730a7e924d4e1342cb1973f5aab39f0710962b7b81aa95b0a433831b67L13-R23): Updated `load_model` function to include `model_tag` parameter and modified calls to backend-specific load functions to pass the tag. [[1]](diffhunk://#diff-a9c13f730a7e924d4e1342cb1973f5aab39f0710962b7b81aa95b0a433831b67L13-R23) [[2]](diffhunk://#diff-a9c13f730a7e924d4e1342cb1973f5aab39f0710962b7b81aa95b0a433831b67L30-R51) [[3]](diffhunk://#diff-a9c13f730a7e924d4e1342cb1973f5aab39f0710962b7b81aa95b0a433831b67R60-R68)
* [`anomstack/io/save.py`](diffhunk://#diff-541989ca5417356cdefd658dae095bc86356a70c5a9b71a77d23ec1ac3ac6939L36-R50): Updated `save_models_local` function to handle `model_tag` and modified model file naming to incorporate the tag.

### Integration with job configuration:

* [`anomstack/jobs/score.py`](diffhunk://#diff-75a9090780ff4db684849473d4982e62c05857ebfee470de72ceaaa2670ff080R61): Added `model_tag` extraction from job specification and updated `load_model` calls to include the tag. [[1]](diffhunk://#diff-75a9090780ff4db684849473d4982e62c05857ebfee470de72ceaaa2670ff080R61) [[2]](diffhunk://#diff-75a9090780ff4db684849473d4982e62c05857ebfee470de72ceaaa2670ff080L114-R115)