### PR TITLE
Make python random

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Supported storage for your trained models:
     </tbody>
 </table>
 
-Supported ways to receive alerts:
+Supported ways to receive [alerts](#alerts):
 
 <table>
     <thead>

--- a/anomstack/jobs/plot.py
+++ b/anomstack/jobs/plot.py
@@ -14,10 +14,10 @@ from dagster import (
     MetadataValue,
     ScheduleDefinition,
     asset,
+    get_dagster_logger,
     job,
     op,
 )
-from dagster import get_dagster_logger
 
 from anomstack.config import specs
 from anomstack.df.resample import resample

--- a/metrics/examples/README.md
+++ b/metrics/examples/README.md
@@ -1,3 +1,113 @@
 # Examples
 
 Some example metric batch sub folders. For example you might have one per source or subject, or whatever makes most sense to you really.
+
+- [bigquery](bigquery/): Example of a BigQuery metric batch.
+- [eirgrid](eirgrid/): Example of a metric batch that uses a custom python `ingest_fn` parameter to just use python to create an `ingest()` function that returns a pandas df.
+- [example_jinja](example_jinja/): Example of a metric batch that uses Jinja templating.
+- [example_simple](example_simple/): Example of a simple metric batch.
+- [example_sql_file](example_sql_file/): Example of a metric batch that uses a SQL file.
+- [freq](freq/): Example of a metric batch that uses the `freq` parameter.
+- [gsod](gsod/): Example of a metric batch that uses GSOD data from BigQuery.
+- [gtrends](gtrends/): Example of a metric batch that uses Google Trends data from BigQuery.
+- [hackernews](hackernews/): Example of a metric batch that uses the Hacker News API.
+- [netdata](netdata/): Example of a metric batch that uses the Netdata API.
+- [netdata_httpcheck](netdata_httpcheck/): Example of a metric batch that uses the Netdata API to check the status of a website.
+- [python](python/): Example of a metric batch that uses a custom python `ingest_fn` parameter to just use python to create an `ingest()` function that returns a pandas df.
+- [s3](s3/): Example of a metric batch that uses S3.
+- [sales](sales/): Example of a metric batch that uses a SQL file.
+- [snowflake](snowflake/): Example of a metric batch that uses Snowflake.
+- [tomtom](tomtom/): Example of a metric batch that uses the TomTom API.
+- [users](users/): Example of a metric batch that uses a SQL file.
+- [weather](weather/): Example of a metric batch that uses Open Meteo data.
+- [weather_forecast](weather_forecast/): Example of a metric batch that uses weather forecast data from Snowflake.
+- [yfinance](yfinance/): Example of a metric batch that uses the Yahoo Finance API.
+
+
+```
+.
+├── README.md
+├── bigquery
+│   ├── README.md
+│   └── bigquery_example_simple
+│       ├── README.md
+│       └── bigquery_example_simple.yaml
+├── eirgrid
+│   ├── README.md
+│   ├── eirgrid.py
+│   └── eirgrid.yaml
+├── example_jinja
+│   ├── README.md
+│   └── example_jinja.yaml
+├── example_simple
+│   ├── README.md
+│   └── example_simple.yaml
+├── example_sql_file
+│   ├── README.md
+│   ├── example_sql_file.sql
+│   └── example_sql_file.yaml
+├── freq
+│   ├── README.md
+│   └── freq.yaml
+├── gsod
+│   ├── README.md
+│   ├── gsod.sql
+│   └── gsod.yaml
+├── gtrends
+│   ├── README.md
+│   ├── gtrends.sql
+│   └── gtrends.yaml
+├── hackernews
+│   ├── README.md
+│   ├── hn_top_stories_scores.py
+│   └── hn_top_stories_scores.yaml
+├── netdata
+│   ├── README.md
+│   ├── netdata.py
+│   └── netdata.yaml
+├── netdata_httpcheck
+│   ├── netdata_httpcheck.py
+│   └── netdata_httpcheck.yaml
+├── python
+│   ├── README.md
+│   └── python_ingest_simple
+│       ├── README.md
+│       ├── ingest.py
+│       └── python_ingest_simple.yaml
+├── s3
+│   ├── README.md
+│   └── s3_example_simple
+│       ├── README.md
+│       └── s3_example_simple.yaml
+├── sales
+│   ├── README.md
+│   ├── sales.sql
+│   └── sales.yaml
+├── snowflake
+│   ├── README.md
+│   └── snowflake_example_simple
+│       ├── README.md
+│       └── snowflake_example_simple.yaml
+├── tomtom
+│   ├── README.md
+│   ├── tomtom.py
+│   └── tomtom.yaml
+├── users
+│   ├── README.md
+│   ├── users.sql
+│   └── users.yaml
+├── weather
+│   ├── README.md
+│   ├── ingest_weather.py
+│   └── weather.yaml
+├── weather_forecast
+│   ├── README.md
+│   ├── weather_forecast.sql
+│   └── weather_forecast.yaml
+└── yfinance
+    ├── README.md
+    ├── yfinance.py
+    └── yfinance.yaml
+
+25 directories, 58 files
+```

--- a/metrics/examples/python/README.md
+++ b/metrics/examples/python/README.md
@@ -1,3 +1,3 @@
 # Python Examples
 
-Examples using a custom python `ingest_fn` paramater to just use python to create an `ingest()` function that returns a pandas df.
+Examples using a custom python `ingest_fn` parameter to just use python to create an `ingest()` function that returns a pandas df.

--- a/metrics/examples/python/python_ingest_simple/ingest.py
+++ b/metrics/examples/python/python_ingest_simple/ingest.py
@@ -1,11 +1,12 @@
 def ingest():
     """
-    Generate random metrics data with occasional anomalies (spikes, drops, 
+    Generate random metrics data with occasional anomalies (spikes, drops,
     or plateaus).
     """
 
     import random
     import time
+
     import pandas as pd
 
     # Define the number of metrics

--- a/metrics/examples/python/python_ingest_simple/ingest.py
+++ b/metrics/examples/python/python_ingest_simple/ingest.py
@@ -19,9 +19,10 @@ def ingest():
     # Different anomaly types
     anomaly_types = ["spike", "drop", "plateau"]
 
-    # Generate random metrics and introduce occasional anomalies (1-5% chance)
+    # Generate random metrics and introduce occasional anomalies (1% chance)
     anomaly_chance = random.random()
-    anomaly_type = random.choice(anomaly_types) if anomaly_chance <= 0.05 else None
+    anomaly_type = (random.choice(anomaly_types)
+                    if anomaly_chance <= 0.01 else None)
 
     for metric in metrics:
         if anomaly_type == "spike":

--- a/metrics/examples/python/python_ingest_simple/ingest.py
+++ b/metrics/examples/python/python_ingest_simple/ingest.py
@@ -1,21 +1,50 @@
 def ingest():
+    """
+    Generate random metrics data with occasional anomalies (spikes, drops, 
+    or plateaus).
+    """
+
     import random
     import time
-
     import pandas as pd
 
-    # generate random metrics
-    metric1_value = random.uniform(0, 10)
-    metric2_value = random.uniform(0, 10)
+    # Define the number of metrics
+    metrics = ["metric1", "metric2", "metric3", "metric4", "metric5"]
+    metric_values = []
 
-    # get current timestamp
+    # Get current timestamp
     current_timestamp = int(time.time())
 
-    # make df
+    # Different anomaly types
+    anomaly_types = ["spike", "drop", "plateau"]
+
+    # Generate random metrics and introduce occasional anomalies (1-5% chance)
+    anomaly_chance = random.random()
+    anomaly_type = random.choice(anomaly_types) if anomaly_chance <= 0.05 else None
+
+    for metric in metrics:
+        if anomaly_type == "spike":
+            # Generate a spike (e.g., a value significantly higher than normal)
+            metric_value = random.uniform(15, 30)
+        elif anomaly_type == "drop":
+            # Generate a drop (e.g., a negative or significantly low value)
+            metric_value = random.uniform(-10, -1)
+        elif anomaly_type == "plateau":
+            # Generate the same value for all metrics (e.g., a plateau)
+            plateau_value = random.uniform(5, 6)
+            metric_values = [plateau_value] * len(metrics)
+            break  # Exit the loop early since all metrics have the same value
+        else:
+            # Generate a normal value
+            metric_value = random.uniform(0, 10)
+
+        metric_values.append(metric_value)
+
+    # Create a DataFrame with the metric data
     data = {
-        "metric_name": ["metric1", "metric2"],
-        "metric_value": [metric1_value, metric2_value],
-        "metric_timestamp": [current_timestamp, current_timestamp],
+        "metric_name": metrics,
+        "metric_value": metric_values,
+        "metric_timestamp": [current_timestamp] * len(metrics),
     }
     df = pd.DataFrame(data)
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -2,7 +2,7 @@ import logging
 
 import pytest
 
-from anomstack.main import ingest_jobs, ingest_schedules, jobs, schedules, sensors
+from anomstack.main import ingest_jobs, ingest_schedules, jobs, schedules
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
This pull request includes several changes across multiple files to enhance logging, improve documentation, and add functionality for generating random metrics data with anomalies. The most important changes are detailed below:

### Logging Enhancements:
* Added `get_dagster_logger` to `anomstack/jobs/plot.py` for improved logging capabilities.
* Implemented a check for empty data frames in `make_plot` function and added logging for cases with no data to plot. [[1]](diffhunk://#diff-bdf291ba71c2cc5455801cde606f02ec7c2f60af44cac703e097874b4678b2ddR101-R102) [[2]](diffhunk://#diff-bdf291ba71c2cc5455801cde606f02ec7c2f60af44cac703e097874b4678b2ddR112-R115)

### Documentation Improvements:
* Updated `README.md` in `metrics/examples/` to include a comprehensive list of example metric batches.
* Corrected a typo in `metrics/examples/python/README.md`.

### Functionality Additions:
* Enhanced `ingest.py` in `metrics/examples/python/python_ingest_simple/` to generate random metrics data with occasional anomalies such as spikes, drops, and plateaus.

### Minor Changes:
* Updated the `Supported ways to receive alerts` section in `README.md` to include a link to the alerts section.
* Removed an unused import in `tests/test_main.py`.