### PR TITLE
Add change snooze n

### DIFF
--- a/anomstack/jobs/change.py
+++ b/anomstack/jobs/change.py
@@ -62,6 +62,7 @@ def build_change_job(spec: dict) -> JobDefinition:
     metric_tags = spec.get("metric_tags", {})
     change_threshold = spec.get("change_threshold", 3.5)
     change_detect_last_n = spec.get("change_detect_last_n", 1)
+    change_snooze_n = spec.get("change_snooze_n", 3)
 
     @job(
         name=f"{metric_batch}_change",

--- a/anomstack/ml/change.py
+++ b/anomstack/ml/change.py
@@ -10,7 +10,10 @@ from pyod.models.mad import MAD
 
 
 def detect_change(
-    df_metric: pd.DataFrame, threshold: float = 3.5, detect_last_n: int = 1
+    df_metric: pd.DataFrame,
+    threshold: float = 3.5,
+    detect_last_n: int = 1,
+    snooze_n: int = 3
 ) -> pd.DataFrame:
     """
     Detects change in a metric based on the Median Absolute Deviation (MAD)
@@ -22,6 +25,8 @@ def detect_change(
             Defaults to 3.5.
         detect_last_n (int, optional): Number of last observations to use for
             detection. Defaults to 1.
+        snooze_n (int, optional): Number of observations to snooze after a
+            change is detected. Defaults to 3.
 
     Returns:
         pd.DataFrame: DataFrame with the detected change information.
@@ -41,10 +46,18 @@ def detect_change(
     df_metric["metric_score"] = list(X_train_scores) + list(y_detect_scores)
     df_metric["metric_alert"] = np.where((df_metric["metric_score"] > threshold),1,0)
     logger.debug(f"df_metric:\n{df_metric}")
-    if df_metric["metric_alert"].tail(detect_last_n).sum() > 0:
-        logger.info(f"change detected for {metric_name} at {X_detect_timestamps}")
-
-        return df_metric
+    change_detected_count = df_metric["metric_alert"].tail(detect_last_n).sum()
+    recent_change_detected_count = df_metric["metric_alert"].tail(snooze_n).sum()
+    if change_detected_count > 0:
+        if recent_change_detected_count <= 1:
+            logger.info(f"change detected for {metric_name} at {X_detect_timestamps}")
+            return df_metric
+        else:
+            logger.info(
+                f"change detected for {metric_name} at {X_detect_timestamps}, "
+                f"but snoozing as {recent_change_detected_count} recent changes already detected"
+            )
+            return pd.DataFrame()
     else:
         logger.info(f"no change detected for {metric_name} at {X_detect_timestamps}")
 

--- a/metrics/defaults/defaults.yaml
+++ b/metrics/defaults/defaults.yaml
@@ -34,6 +34,7 @@ alert_recent_n: 1 # only alert on recent n so as to avoid continually alerting.
 alert_smooth_n: 3 # smooth anomaly score over rolling n to avoid being too trigger happy.
 alert_snooze_n: 3 # snooze alerts for n periods after an alert.
 change_smooth_n: 1 # smooth metric values as part of change detection.
+change_snooze_n: 3 # snooze change detection for n periods after a change.
 alert_threshold: 0.8 # threshold for smoothed anomaly score above which to alert on.
 change_threshold: 3.5 # threshold for PyOD MAD based change detection above which to alert on.
 change_detect_last_n: 1 # number of last n observations to detect changes on.


### PR DESCRIPTION
This pull request introduces a new feature to snooze change detection for a specified number of periods after a change is detected. The most important changes include adding a new parameter `snooze_n` to the change detection function and updating the logic to handle snoozing.

Changes related to snooze functionality:

* [`anomstack/jobs/change.py`](diffhunk://#diff-1aa29dc3fa4ff0ab5ee651a82e8c9c06fbbce4b8d83157ae34db41cbea8c39b9R65): Added a new configuration parameter `change_snooze_n` to the `noop` function to specify the number of periods to snooze change detection.
* `anomstack/ml/change.py`: 
  * Added the `snooze_n` parameter to the `detect_change` function signature.
  * Updated the docstring of `detect_change` to include the description of the `snooze_n` parameter.
  * Modified the change detection logic to check for recent changes and snooze if necessary, returning an empty DataFrame if snoozing.

Configuration updates:

* [`metrics/defaults/defaults.yaml`](diffhunk://#diff-87b1ac24a54e3a83a9a0c5caddafbc2b2e4c8df4cee00ebfe10c73968112b2f7R37): Added a default value for `change_snooze_n` to the configuration file.