### PR TITLE
Clean up change alert snooze logic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,17 +16,17 @@ SHELL=/bin/bash
 dashboard:
 	streamlit run ./dashboard.py --server.port 8501
 
-# start streamlit dashboard as a daemon
+# start streamlit dashboard as a daemon with no log file
 dashboardd:
-	nohup streamlit run ./dashboard.py --server.port 8501 &
+	nohup streamlit run ./dashboard.py --server.port 8501 > /dev/null 2>&1 &
 
 # start dagster locally
 local:
 	dagster dev -f anomstack/main.py
 
-# start dagster locally as a daemon
+# start dagster locally as a daemon with no log file
 locald:
-	nohup dagster dev -f anomstack/main.py &
+	nohup dagster dev -f anomstack/main.py > /dev/null 2>&1 &
 
 # kill any running dagster process
 kill-locald:

--- a/anomstack/df/utils.py
+++ b/anomstack/df/utils.py
@@ -1,0 +1,18 @@
+from io import StringIO
+from dagster import get_dagster_logger
+import pandas as pd
+
+
+def log_df_info(df: pd.DataFrame, logger=None):
+    """
+    Logs the info of a DataFrame to the logger.
+
+    Parameters:
+    df (pd.DataFrame): The DataFrame whose info needs to be logged.
+    """
+    if not logger:
+        logger = get_dagster_logger()
+    buffer = StringIO()
+    df.info(buf=buffer)
+    info_str = buffer.getvalue()
+    logger.info("df.info():\n%s", info_str)

--- a/anomstack/external/duckdb/duckdb.py
+++ b/anomstack/external/duckdb/duckdb.py
@@ -28,10 +28,7 @@ def read_sql_duckdb(sql: str) -> pd.DataFrame:
     os.makedirs(os.path.dirname(duckdb_path), exist_ok=True)
 
     conn = connect(duckdb_path)
-
-    logger.debug(f"sql:\n{sql}")
     df = query(connection=conn, query=sql).df()
-    logger.debug(f"df:\n{df}")
 
     return df
 

--- a/anomstack/external/gcp/bigquery.py
+++ b/anomstack/external/gcp/bigquery.py
@@ -25,18 +25,11 @@ def read_sql_bigquery(sql: str) -> pd.DataFrame:
     Returns:
         pd.DataFrame: The result of the query as a DataFrame.
     """
-
-    logger = get_dagster_logger()
-
-    logger.debug(f"sql:\n{sql}")
-
     credentials = get_google_credentials()
-
     df = pd.read_gbq(
         query=sql,
         credentials=credentials,
     )
-    logger.debug(f"df:\n{df}")
 
     return df
 

--- a/anomstack/external/snowflake/snowflake.py
+++ b/anomstack/external/snowflake/snowflake.py
@@ -3,7 +3,6 @@ Some utilities for working with Snowflake.
 """
 
 import pandas as pd
-from dagster import get_dagster_logger
 from snowflake import connector
 
 from anomstack.external.snowflake.credentials import get_snowflake_credentials
@@ -21,11 +20,6 @@ def read_sql_snowflake(sql: str, cols_lowercase: bool = True) -> pd.DataFrame:
     Returns:
         pd.DataFrame: The result of the SQL query as a pandas DataFrame.
     """
-
-    logger = get_dagster_logger()
-
-    logger.debug(f"sql:\n{sql}")
-
     credentials = get_snowflake_credentials()
 
     conn = connector.connect(
@@ -40,8 +34,6 @@ def read_sql_snowflake(sql: str, cols_lowercase: bool = True) -> pd.DataFrame:
 
     if cols_lowercase:
         df.columns = df.columns.str.lower()
-
-    logger.debug(f"df:\n{df}")
 
     return df
 

--- a/anomstack/external/sqlite/sqlite.py
+++ b/anomstack/external/sqlite/sqlite.py
@@ -29,9 +29,7 @@ def read_sql_sqlite(sql: str) -> pd.DataFrame:
 
     conn = sqlite3.connect(sqlite_path)
 
-    logger.debug(f"sql:\n{sql}")
     df = pd.read_sql_query(sql, conn)
-    logger.debug(f"df:\n{df}")
 
     conn.close()
     return df

--- a/anomstack/jobs/change.py
+++ b/anomstack/jobs/change.py
@@ -24,7 +24,9 @@ from anomstack.ml.change import detect_change
 from anomstack.sql.read import read_sql
 from anomstack.validate.validate import validate_df
 
-ANOMSTACK_MAX_RUNTIME_SECONDS_TAG = os.getenv("ANOMSTACK_MAX_RUNTIME_SECONDS_TAG", 3600)
+ANOMSTACK_MAX_RUNTIME_SECONDS_TAG = os.getenv(
+    "ANOMSTACK_MAX_RUNTIME_SECONDS_TAG", 3600
+)
 
 
 def build_change_job(spec: dict) -> JobDefinition:
@@ -62,7 +64,6 @@ def build_change_job(spec: dict) -> JobDefinition:
     metric_tags = spec.get("metric_tags", {})
     change_threshold = spec.get("change_threshold", 3.5)
     change_detect_last_n = spec.get("change_detect_last_n", 1)
-    change_snooze_n = spec.get("change_snooze_n", 3)
 
     @job(
         name=f"{metric_batch}_change",

--- a/anomstack/ml/change.py
+++ b/anomstack/ml/change.py
@@ -12,8 +12,7 @@ from pyod.models.mad import MAD
 def detect_change(
     df_metric: pd.DataFrame,
     threshold: float = 3.5,
-    detect_last_n: int = 1,
-    snooze_n: int = 3
+    detect_last_n: int = 1
 ) -> pd.DataFrame:
     """
     Detects change in a metric based on the Median Absolute Deviation (MAD)
@@ -25,8 +24,6 @@ def detect_change(
             Defaults to 3.5.
         detect_last_n (int, optional): Number of last observations to use for
             detection. Defaults to 1.
-        snooze_n (int, optional): Number of observations to snooze after a
-            change is detected. Defaults to 3.
 
     Returns:
         pd.DataFrame: DataFrame with the detected change information.
@@ -44,24 +41,19 @@ def detect_change(
     y_detect_scores = detector.decision_function(X_detect)
     logger.debug(f"y_detect_scores: {y_detect_scores}")
     df_metric["metric_score"] = list(X_train_scores) + list(y_detect_scores)
-    df_metric["metric_alert"] = np.where((df_metric["metric_score"] > threshold),1,0)
+    df_metric["metric_alert"] = np.where(
+        df_metric["metric_score"] > threshold, 1, 0
+    )
     logger.debug(f"df_metric:\n{df_metric}")
     change_detected_count = df_metric["metric_alert"].tail(detect_last_n).sum()
-    recent_change_detected_count = df_metric["metric_alert"].tail(snooze_n).sum()
     if change_detected_count > 0:
-        # TODO: clean up the logic here as this could stay
-        # snoozed for a long time until we see sufficient 0's
-        # in last snooze_n so its more like a dyanmic suppression
-        if recent_change_detected_count <= 1:
-            logger.info(f"change detected for {metric_name} at {X_detect_timestamps}")
-            return df_metric
-        else:
-            logger.info(
-                f"change detected for {metric_name} at {X_detect_timestamps}, "
-                f"but snoozing as {recent_change_detected_count} recent changes already detected"
-            )
-            return pd.DataFrame()
+        logger.info(
+            f"change detected for {metric_name} at {X_detect_timestamps}"
+        )
+        return df_metric
     else:
-        logger.info(f"no change detected for {metric_name} at {X_detect_timestamps}")
+        logger.info(
+            f"no change detected for {metric_name} at {X_detect_timestamps}"
+        )
 
         return pd.DataFrame()

--- a/anomstack/sql/read.py
+++ b/anomstack/sql/read.py
@@ -9,10 +9,13 @@ import pandas as pd
 import sqlglot
 from dagster import get_dagster_logger
 
+from anomstack.df.utils import log_df_info
 from anomstack.external.duckdb.duckdb import read_sql_duckdb
 from anomstack.external.gcp.bigquery import read_sql_bigquery
 from anomstack.external.snowflake.snowflake import read_sql_snowflake
 from anomstack.external.sqlite.sqlite import read_sql_sqlite
+
+pd.options.display.max_columns = 10
 
 
 def db_translate(sql: str, db: str) -> str:
@@ -58,7 +61,7 @@ def read_sql(sql: str, db: str) -> pd.DataFrame:
 
     sql = db_translate(sql, db)
 
-    logger.debug(f"sql:\n{sql}")
+    logger.debug(f"-- read_sql() is about to read this qry:\n{sql}")
 
     if db == "bigquery":
         df = read_sql_bigquery(sql)
@@ -71,6 +74,8 @@ def read_sql(sql: str, db: str) -> pd.DataFrame:
     else:
         raise ValueError(f"Unknown db: {db}")
 
-    logger.debug(f"df:\n{df}")
+    log_df_info(df, logger)
+    logger.debug(f"df.head():\n{df.head()}")
+    logger.debug(f"df.tail():\n{df.tail()}")
 
     return df


### PR DESCRIPTION
This pull request includes several changes aimed at improving logging, removing unused parameters, and updating SQL templates. The most important changes include adding a new utility function for logging DataFrame information, removing debug logging from SQL reading functions, and updating the SQL template for change detection.

### Logging Improvements:
* Added a `log_df_info` function in `anomstack/df/utils.py` to log DataFrame information using Dagster's logger.
* Updated `read_sql` in `anomstack/sql/read.py` to use the new `log_df_info` function and added additional logging for DataFrame heads and tails. [[1]](diffhunk://#diff-91cf917cae92a87c181c6aaf5e35e005555721ba9e48317cedd28bdad32481bbR12-R19) [[2]](diffhunk://#diff-91cf917cae92a87c181c6aaf5e35e005555721ba9e48317cedd28bdad32481bbL74-R79)

### Debug Logging Removal:
* Removed debug logging from SQL reading functions in `anomstack/external/duckdb/duckdb.py`, `anomstack/external/gcp/bigquery.py`, `anomstack/external/snowflake/snowflake.py`, and `anomstack/external/sqlite/sqlite.py`. [[1]](diffhunk://#diff-fee38335e5d2ae81780bfd889ea8d85b8b205ec6382273b99c89837b1c27572bL31-L34) [[2]](diffhunk://#diff-5a21185089e8492120e3a7d7ef1f50f1f0907b56c346184bb9f0ffe197748e73L28-L39) [[3]](diffhunk://#diff-f3df0ae1590528decdbe2ce3457079350e296830b39609a965f3a222532b848cL24-L28) [[4]](diffhunk://#diff-bb44a0620fca94c34ebd5f4e88bcad569eb764a359bf754fe2847e4d60b477a7L32-L34)

### SQL Template Update:
* Updated the SQL template in `metrics/defaults/sql/change.sql` to improve readability and add comments for better understanding.

### Parameter Removal:
* Removed the `snooze_n` parameter from the `detect_change` function in `anomstack/ml/change.py` and updated related logic. [[1]](diffhunk://#diff-4ffdec85954d4edc61905652ccf4b5861d49f7d53336a67a45f00fc93fc7454cL15-R15) [[2]](diffhunk://#diff-4ffdec85954d4edc61905652ccf4b5861d49f7d53336a67a45f00fc93fc7454cL47-L65)

### Miscellaneous:
* Modified `Makefile` to redirect daemon process logs to `/dev/null`.
* Adjusted the environment variable retrieval for `ANOMSTACK_MAX_RUNTIME_SECONDS_TAG` in `anomstack/jobs/change.py` for better formatting.