### PR TITLE
ability to include/exclude specific metrics in change detection

### DIFF
--- a/metrics/defaults/defaults.yaml
+++ b/metrics/defaults/defaults.yaml
@@ -1,7 +1,10 @@
 # default values to be applied to all batches unless overridden in metric batch specific yaml files.
 db: "sqlite" # database type to use.
 table_key: "metrics" # table to store metrics in.
+
+############################################
 # model params
+############################################
 model_path: "local://./models" # path to where models are to be stored.
 # model_path: "gs://your-bucket/models" # gcs path to where models are to be stored.
 # model_path: "s3://your-bucket/models" # s3 path to where models are to be stored.
@@ -19,7 +22,16 @@ model_combination_method: 'mean' # method to combine model scores, 'mean', 'min'
 train_max_n: 2500 # max number of observations for training a model.
 train_min_n: 14 # min number of observations for training a model.
 score_max_n: 25 # max n to pull for scoring to avoid pulling more than needed.
+preprocess_params:
+  diff_n: 1 # 1 will use diff, 0 will use raw metric values.
+  smooth_n: 3 # how much smoothing to apply in preprocessing.
+  lags_n: 5 # how many lags to include in feature vector.
+  freq: null # how often to resample for different aggregation levels than ingested at. Default of null means no resampling.
+  freq_agg: 'mean' # default aggregation function to use for resampling if freq != None.
+
+############################################
 # alert params
+############################################
 alert_methods: "email,slack" # comma separated list of alert methods to use eg "email,slack".
 alert_always: False # if True, always send alerts, even if no anomalies.
 alert_metric_timestamp_max_days_ago: 45 # don't alert on metrics older than this.
@@ -28,7 +40,10 @@ alert_max_n: 250 # max n to include and plot in an alert.
 alert_smooth_n: 3 # smooth anomaly score over rolling n to avoid being too trigger happy.
 alert_snooze_n: 3 # snooze alerts for n periods after an alert.
 alert_threshold: 0.8 # threshold for smoothed anomaly score above which to alert on.
+
+############################################
 # change detection params
+############################################
 change_metric_timestamp_max_days_ago: 45 # don't all metrics older than this into change detection.
 change_max_n: 250 # max n to include in change detection.
 change_smooth_n: 1 # smooth metric values as part of change detection.
@@ -41,28 +56,17 @@ change_detect_last_n: 1 # number of last n observations to detect changes on.
 # optional list of metrics to exclude from change detection.
 # change_exclude_metrics:
 #   - 'dummy_exclude_metric'
+
+############################################
 # llmalert params
+############################################
 llmalert_recent_n: 5 # only llmalert on recent n so as to avoid continually alerting.
 llmalert_smooth_n: 3 # smooth metric value prior to sending to llm.
 llmalert_metric_rounding: 4 # round metric values to this number of decimal places.
-# other params
-disable_batch: False # if you want to disable a metric batch for some reason.
-ingest_metric_rounding: 4 # round metric values to this number of decimal places.
-score_metric_rounding: 4 # round metric scores to this number of decimal places.
-summary_metric_timestamp_max_days_ago: 1 # number of days to look over for summary email.
-# metric_tags:
-#   metric_name:
-#     key1: value1
-#     key2: value2
-preprocess_fn: >
-  {% include "./defaults/python/preprocess.py" %}
-preprocess_params:
-  diff_n: 1 # 1 will use diff, 0 will use raw metric values.
-  smooth_n: 3 # how much smoothing to apply in preprocessing.
-  lags_n: 5 # how many lags to include in feature vector.
-  freq: null # how often to resample for different aggregation levels than ingested at. Default of null means no resampling.
-  freq_agg: 'mean' # default aggregation function to use for resampling if freq != None.
+
+############################################
 # schedules
+############################################
 ingest_cron_schedule: "*/3 * * * *" # cron schedule for ingest jobs
 ingest_default_schedule_status: 'STOPPED' # default schedule status for ingest jobs (RUNNING or STOPPED)
 train_cron_schedule: "*/5 * * * *" # cron schedule for training jobs
@@ -78,7 +82,10 @@ llmalert_default_schedule_status: 'STOPPED' # default schedule status for llmale
 plot_cron_schedule: "*/5 * * * *" # cron schedule for plot jobs
 plot_default_schedule_status: 'STOPPED' # default schedule status for plot jobs (RUNNING or STOPPED)
 summary_cron_schedule: "0 9 * * *" # cron schedule for summary job
-# sql templates
+
+############################################
+# templates
+############################################
 # default templated train sql
 train_sql: >
   {% include "./defaults/sql/train.sql" %}
@@ -99,6 +106,22 @@ dashboard_sql: >
 # default templated summary sql
 summary_sql: >
   {% include "./defaults/sql/summary.sql" %}
+preprocess_fn: >
+  {% include "./defaults/python/preprocess.py" %}
+prompt_fn: >
+  {% include "./defaults/python/prompt.py" %}
+
+############################################
+# other params
+############################################
+disable_batch: False # if you want to disable a metric batch for some reason.
+ingest_metric_rounding: 4 # round metric values to this number of decimal places.
+score_metric_rounding: 4 # round metric scores to this number of decimal places.
+summary_metric_timestamp_max_days_ago: 1 # number of days to look over for summary email.
+# metric_tags:
+#   metric_name:
+#     key1: value1
+#     key2: value2
 disable_ingest: False # if you want to disable ingest job for some reason.
 disable_train: False # if you want to disable train job for some reason.
 disable_score: False # if you want to disable score job for some reason.
@@ -107,5 +130,3 @@ disable_change: False # if you want to disable change detection job for some rea
 disable_llmalert: True # if you want to disable llmalert job for some reason.
 disable_plot: False # if you want to disable plot job for some reason.
 disable_summary: False # if you want to disable summary job for some reason.
-prompt_fn: >
-  {% include "./defaults/python/prompt.py" %}

--- a/metrics/defaults/defaults.yaml
+++ b/metrics/defaults/defaults.yaml
@@ -1,6 +1,7 @@
 # default values to be applied to all batches unless overridden in metric batch specific yaml files.
 db: "sqlite" # database type to use.
 table_key: "metrics" # table to store metrics in.
+# model params
 model_path: "local://./models" # path to where models are to be stored.
 # model_path: "gs://your-bucket/models" # gcs path to where models are to be stored.
 # model_path: "s3://your-bucket/models" # s3 path to where models are to be stored.
@@ -15,34 +16,44 @@ model_configs:
     model_params:
       contamination: 0.01
 model_combination_method: 'mean' # method to combine model scores, 'mean', 'min' or 'max'.
+train_max_n: 2500 # max number of observations for training a model.
+train_min_n: 14 # min number of observations for training a model.
+score_max_n: 25 # max n to pull for scoring to avoid pulling more than needed.
+# alert params
+alert_methods: "email,slack" # comma separated list of alert methods to use eg "email,slack".
+alert_always: False # if True, always send alerts, even if no anomalies.
+alert_metric_timestamp_max_days_ago: 45 # don't alert on metrics older than this.
+alert_recent_n: 1 # only alert on recent n so as to avoid continually alerting.
+alert_max_n: 250 # max n to include and plot in an alert.
+alert_smooth_n: 3 # smooth anomaly score over rolling n to avoid being too trigger happy.
+alert_snooze_n: 3 # snooze alerts for n periods after an alert.
+alert_threshold: 0.8 # threshold for smoothed anomaly score above which to alert on.
+# change detection params
+change_metric_timestamp_max_days_ago: 45 # don't all metrics older than this into change detection.
+change_max_n: 250 # max n to include in change detection.
+change_smooth_n: 1 # smooth metric values as part of change detection.
+change_snooze_n: 3 # snooze change detection for n periods after a change.
+change_threshold: 3.5 # threshold for PyOD MAD based change detection above which to alert on.
+change_detect_last_n: 1 # number of last n observations to detect changes on.
+# optional list of metrics to include in change detection.
+# change_include_metrics:
+#   - 'dummy_include_metric'
+# optional list of metrics to exclude from change detection.
+# change_exclude_metrics:
+#   - 'dummy_exclude_metric'
+# llmalert params
+llmalert_recent_n: 5 # only llmalert on recent n so as to avoid continually alerting.
+llmalert_smooth_n: 3 # smooth metric value prior to sending to llm.
+llmalert_metric_rounding: 4 # round metric values to this number of decimal places.
+# other params
+disable_batch: False # if you want to disable a metric batch for some reason.
+ingest_metric_rounding: 4 # round metric values to this number of decimal places.
+score_metric_rounding: 4 # round metric scores to this number of decimal places.
+summary_metric_timestamp_max_days_ago: 1 # number of days to look over for summary email.
 # metric_tags:
 #   metric_name:
 #     key1: value1
 #     key2: value2
-disable_batch: False # if you want to disable a metric batch for some reason.
-train_max_n: 2500 # max number of observations for training a model.
-train_min_n: 14 # min number of observations for training a model.
-score_max_n: 25 # max n to pull for scoring to avoid pulling more than needed.
-ingest_metric_rounding: 4 # round metric values to this number of decimal places.
-score_metric_rounding: 4 # round metric scores to this number of decimal places.
-alert_max_n: 250 # max n to include and plot in an alert.
-change_max_n: 250 # max n to include in change detection.
-alert_metric_timestamp_max_days_ago: 45 # don't alert on metrics older than this.
-change_metric_timestamp_max_days_ago: 45 # don't all metrics older than this into change detection.
-summary_metric_timestamp_max_days_ago: 1 # number of days to look over for summary email.
-alert_recent_n: 1 # only alert on recent n so as to avoid continually alerting.
-alert_smooth_n: 3 # smooth anomaly score over rolling n to avoid being too trigger happy.
-alert_snooze_n: 3 # snooze alerts for n periods after an alert.
-change_smooth_n: 1 # smooth metric values as part of change detection.
-change_snooze_n: 3 # snooze change detection for n periods after a change.
-alert_threshold: 0.8 # threshold for smoothed anomaly score above which to alert on.
-change_threshold: 3.5 # threshold for PyOD MAD based change detection above which to alert on.
-change_detect_last_n: 1 # number of last n observations to detect changes on.
-alert_always: False # if True, always send alerts, even if no anomalies.
-alert_methods: "email" # comma separated list of alert methods to use eg "email,slack".
-llmalert_recent_n: 5 # only llmalert on recent n so as to avoid continually alerting.
-llmalert_smooth_n: 3 # smooth metric value prior to sending to llm.
-llmalert_metric_rounding: 4 # round metric values to this number of decimal places.
 preprocess_fn: >
   {% include "./defaults/python/preprocess.py" %}
 preprocess_params:
@@ -51,6 +62,7 @@ preprocess_params:
   lags_n: 5 # how many lags to include in feature vector.
   freq: null # how often to resample for different aggregation levels than ingested at. Default of null means no resampling.
   freq_agg: 'mean' # default aggregation function to use for resampling if freq != None.
+# schedules
 ingest_cron_schedule: "*/3 * * * *" # cron schedule for ingest jobs
 ingest_default_schedule_status: 'STOPPED' # default schedule status for ingest jobs (RUNNING or STOPPED)
 train_cron_schedule: "*/5 * * * *" # cron schedule for training jobs
@@ -66,6 +78,7 @@ llmalert_default_schedule_status: 'STOPPED' # default schedule status for llmale
 plot_cron_schedule: "*/5 * * * *" # cron schedule for plot jobs
 plot_default_schedule_status: 'STOPPED' # default schedule status for plot jobs (RUNNING or STOPPED)
 summary_cron_schedule: "0 9 * * *" # cron schedule for summary job
+# sql templates
 # default templated train sql
 train_sql: >
   {% include "./defaults/sql/train.sql" %}

--- a/metrics/defaults/sql/change.sql
+++ b/metrics/defaults/sql/change.sql
@@ -22,6 +22,16 @@ where
   and
   -- Filter to the last {{ change_metric_timestamp_max_days_ago }} days
   date(metric_timestamp) >= date('now', '-{{ change_metric_timestamp_max_days_ago }} day')
+  {% if change_include_metrics is defined %}
+  and
+  -- Include only the specified metrics
+  metric_name in ({{ ','.join(change_include_metrics) }})
+  {% endif %}
+  {% if change_exclude_metrics is defined %}
+  and
+  -- Exclude the specified metrics
+  metric_name not in ({{ ','.join(change_exclude_metrics) }})
+  {% endif %}
 group by
   metric_timestamp, metric_batch, metric_name
 ),
@@ -42,6 +52,16 @@ where
   and
   -- Filter to the last {{ change_metric_timestamp_max_days_ago }} days
   date(metric_timestamp) >= date('now', '-{{ change_metric_timestamp_max_days_ago }} day')
+  {% if change_include_metrics is defined %}
+  and
+  -- Include only the specified metrics
+  metric_name in ({{ ','.join(change_include_metrics) }})
+  {% endif %}
+  {% if change_exclude_metrics is defined %}
+  and
+  -- Exclude the specified metrics
+  metric_name not in ({{ ','.join(change_exclude_metrics) }})
+  {% endif %}
 group by
   metric_timestamp, metric_batch, metric_name
 ),

--- a/metrics/examples/netdata/netdata.yaml
+++ b/metrics/examples/netdata/netdata.yaml
@@ -13,3 +13,5 @@ disable_llmalert: False
 alert_methods: "email,slack"
 ingest_fn: >
   {% include "./examples/netdata/netdata.py" %}
+change_exclude_metrics:
+- london__system_io_reads

--- a/metrics/examples/python/python_ingest_simple/python_ingest_simple.yaml
+++ b/metrics/examples/python/python_ingest_simple/python_ingest_simple.yaml
@@ -1,5 +1,7 @@
-disable_batch: False
+db: "sqlite"
+table_key: "metrics"
 metric_batch: "python_ingest_simple"
+alert_methods: "email,slack"
 ingest_cron_schedule: "*/2 * * * *"
 train_cron_schedule: "*/4 * * * *"
 score_cron_schedule: "*/3 * * * *"


### PR DESCRIPTION
This pull request includes several updates to the `metrics/defaults/defaults.yaml` file to enhance configuration options, particularly for model parameters, alerting, change detection, and scheduling. Additionally, there are changes to SQL templates and example configurations to support these enhancements.

### Configuration Enhancements:

* Added new sections for model parameters, alert parameters, change detection parameters, and other configurations in `metrics/defaults/defaults.yaml`. These include settings for preprocessing, alert methods, change detection, and rounding of metric values. [[1]](diffhunk://#diff-87b1ac24a54e3a83a9a0c5caddafbc2b2e4c8df4cee00ebfe10c73968112b2f7R4-R7) [[2]](diffhunk://#diff-87b1ac24a54e3a83a9a0c5caddafbc2b2e4c8df4cee00ebfe10c73968112b2f7L18-R69) [[3]](diffhunk://#diff-87b1ac24a54e3a83a9a0c5caddafbc2b2e4c8df4cee00ebfe10c73968112b2f7R85-R88) [[4]](diffhunk://#diff-87b1ac24a54e3a83a9a0c5caddafbc2b2e4c8df4cee00ebfe10c73968112b2f7R109-R124) [[5]](diffhunk://#diff-87b1ac24a54e3a83a9a0c5caddafbc2b2e4c8df4cee00ebfe10c73968112b2f7L97-L98)

### SQL Template Updates:

* Updated SQL templates in `metrics/defaults/sql/change.sql` to include conditions for including or excluding specific metrics in change detection queries. [[1]](diffhunk://#diff-930a2ae9fa8dee5df1ce55b087a4ce10ed5b81a4365ec37725eb1b52781b50c4R25-R34) [[2]](diffhunk://#diff-930a2ae9fa8dee5df1ce55b087a4ce10ed5b81a4365ec37725eb1b52781b50c4R55-R64)

### Example Configuration Updates:

* Added `change_exclude_metrics` to the `metrics/examples/netdata/netdata.yaml` example configuration to exclude specific metrics from change detection.
* Updated `metrics/examples/python/python_ingest_simple/python_ingest_simple.yaml` to include database configuration and alert methods.