### PR TITLE
Fix SQL queries to handle null metric values by using ifnull function

### DIFF
--- a/metrics/defaults/sql/change.sql
+++ b/metrics/defaults/sql/change.sql
@@ -42,7 +42,7 @@ select distinct
   metric_timestamp,
   metric_batch,
   metric_name,
-  max(metric_value) as metric_change
+  max(ifnull(metric_value,0)) as metric_change
 from
   {{ table_key }}
 where
@@ -73,7 +73,7 @@ select distinct
   metric_value_data.metric_batch,
   metric_value_data.metric_name,
   metric_value_data.metric_value,
-  metric_change_alert_data.metric_change as metric_change,
+  ifnull(metric_change_alert_data.metric_change,0) as metric_change,
   -- Rank the metric values by recency, with 1 being the most recent
   row_number() over (partition by metric_value_data.metric_name order by metric_value_data.metric_timestamp desc) as metric_value_recency_rank
 from


### PR DESCRIPTION
This pull request includes changes to the `metrics/defaults/sql/change.sql` file to handle null values in the metric calculations. The main changes involve using the `ifnull` function to ensure that null values are treated as zero.

Changes to handle null values:

* [`metrics/defaults/sql/change.sql`](diffhunk://#diff-930a2ae9fa8dee5df1ce55b087a4ce10ed5b81a4365ec37725eb1b52781b50c4L45-R45): Modified the `max(metric_value)` calculation to use `max(ifnull(metric_value,0))` to handle null values.
* [`metrics/defaults/sql/change.sql`](diffhunk://#diff-930a2ae9fa8dee5df1ce55b087a4ce10ed5b81a4365ec37725eb1b52781b50c4L76-R76): Changed the `metric_change` alias to use `ifnull(metric_change_alert_data.metric_change,0)` to ensure null values are treated as zero.