### PR TITLE
Enhance SQLite save function with retry logic for locked database errors

### DIFF
--- a/anomstack/df/utils.py
+++ b/anomstack/df/utils.py
@@ -1,6 +1,7 @@
 from io import StringIO
-from dagster import get_dagster_logger
+
 import pandas as pd
+from dagster import get_dagster_logger
 
 
 def log_df_info(df: pd.DataFrame, logger=None):

--- a/anomstack/external/sqlite/sqlite.py
+++ b/anomstack/external/sqlite/sqlite.py
@@ -4,9 +4,13 @@ Some helper functions for sqlite.
 
 import os
 import sqlite3
+import time
 
 import pandas as pd
 from dagster import get_dagster_logger
+
+MAX_RETRIES = 5
+RETRY_DELAY = 1
 
 
 def read_sql_sqlite(sql: str) -> pd.DataFrame:
@@ -19,25 +23,19 @@ def read_sql_sqlite(sql: str) -> pd.DataFrame:
     Returns:
         pd.DataFrame: The result of the SQL query as a pandas DataFrame.
     """
-
     logger = get_dagster_logger()
-
     sqlite_path = os.environ.get("ANOMSTACK_SQLITE_PATH", "tmpdata/anomstack.db")
-    logger.info(f"sqlite_path:{sqlite_path}")
-
+    logger.info(f"sqlite_path: {sqlite_path}")
     os.makedirs(os.path.dirname(sqlite_path), exist_ok=True)
 
     conn = sqlite3.connect(sqlite_path)
-
     df = pd.read_sql_query(sql, conn)
-
     conn.close()
     return df
 
-
 def save_df_sqlite(df: pd.DataFrame, table_key: str) -> pd.DataFrame:
     """
-    Save df to db.
+    Save df to db with retry logic.
 
     Args:
         df (pd.DataFrame): The DataFrame to save.
@@ -46,21 +44,27 @@ def save_df_sqlite(df: pd.DataFrame, table_key: str) -> pd.DataFrame:
     Returns:
         pd.DataFrame: The input DataFrame.
     """
-
     logger = get_dagster_logger()
-
     sqlite_path = os.environ.get("ANOMSTACK_SQLITE_PATH", "tmpdata/anomstack.db")
-    logger.info(f"sqlite_path:{sqlite_path}")
-
+    logger.info(f"sqlite_path: {sqlite_path}")
     os.makedirs(os.path.dirname(sqlite_path), exist_ok=True)
 
-    conn = sqlite3.connect(sqlite_path)
-
-    try:
-        df.to_sql(table_key, conn, if_exists='append', index=False)
-    except Exception as e:
-        logger.error(f"Error saving DataFrame to SQLite: {e}")
-        raise
-
-    conn.close()
-    return df
+    attempt = 0
+    while attempt < MAX_RETRIES:
+        try:
+            conn = sqlite3.connect(sqlite_path)
+            df.to_sql(table_key, conn, if_exists='append', index=False)
+            conn.close()
+            return df
+        except sqlite3.OperationalError as e:
+            if "database is locked" in str(e):
+                attempt += 1
+                logger.warning(
+                    f"Database is locked; attempt {attempt} of {MAX_RETRIES}. Retrying in {RETRY_DELAY} seconds..."
+                )
+                time.sleep(RETRY_DELAY)
+            else:
+                logger.error(f"Error saving DataFrame to SQLite: {e}")
+                raise
+    # If all retries fail, raise an error
+    raise sqlite3.OperationalError("Database is locked after multiple attempts.")


### PR DESCRIPTION
This pull request includes several changes to the `anomstack` project, focusing on improving logging and adding retry logic for database operations. The most important changes include adding retry logic to the `save_df_sqlite` function, importing necessary modules, and improving the logging setup.

Enhancements to database operations:

* Added retry logic to the `save_df_sqlite` function to handle `sqlite3.OperationalError` when the database is locked. This includes setting `MAX_RETRIES` and `RETRY_DELAY` constants, and implementing a retry loop with logging for each attempt. (`anomstack/external/sqlite/sqlite.py`)
* Imported the `time` module to support the retry delay functionality. (`anomstack/external/sqlite/sqlite.py`)

Logging improvements:

* Improved the logging setup by ensuring the `get_dagster_logger` import is correctly placed and used in the `log_df_info` function. (`anomstack/df/utils.py`)
* Cleaned up the `read_sql_sqlite` function by removing unnecessary blank lines and ensuring the logger is used effectively. (`anomstack/external/sqlite/sqlite.py`)