### PR TITLE
Ressurect llm allert, update to gpt4omini

### DIFF
--- a/.example.env
+++ b/.example.env
@@ -67,7 +67,8 @@ ANOMSTACK_DAGSTER_SQLITE_STORAGE_BASE_DIR=tmp
 
 # OpenAI env vars for LLM based alerts
 ANOMSTACK_OPENAI_KEY=
-ANOMSTACK_OPENAI_MODEL=gpt-3.5-turbo
+ANOMSTACK_OPENAI_MODEL=gpt-4o-mini
+# ANOMSTACK_OPENAI_MODEL=gpt-3.5-turbo
 # ANOMSTACK_OPENAI_MODEL=gpt-4-1106-preview
 
 # some dagster env vars

--- a/anomstack/alerts/email.py
+++ b/anomstack/alerts/email.py
@@ -81,7 +81,7 @@ def send_email_with_plot(
         msg.attach(payload)
 
         context = ssl.create_default_context()
-        with smtplib.SMTP(host, port) as server:
+        with smtplib.SMTP(host, port, timeout=30) as server:
             server.connect(host, port)
             server.starttls(context=context)
             server.login(sender, password)

--- a/anomstack/external/sqlite/sqlite.py
+++ b/anomstack/external/sqlite/sqlite.py
@@ -60,7 +60,8 @@ def save_df_sqlite(df: pd.DataFrame, table_key: str) -> pd.DataFrame:
             if "database is locked" in str(e):
                 attempt += 1
                 logger.warning(
-                    f"Database is locked; attempt {attempt} of {MAX_RETRIES}. Retrying in {RETRY_DELAY} seconds..."
+                    f"Database is locked; attempt {attempt} of {MAX_RETRIES}. "
+                    f"Retrying in {RETRY_DELAY} seconds..."
                 )
                 time.sleep(RETRY_DELAY)
             else:

--- a/anomstack/jobs/llmalert.py
+++ b/anomstack/jobs/llmalert.py
@@ -128,7 +128,7 @@ def build_llmalert_job(spec: dict) -> JobDefinition:
                 # logger.debug(f"df_metric: \n{df_metric}")
 
                 df_prompt = (
-                    df_metric[["metric_value", "metric_recency"]]
+                    df_metric[["metric_timestamp", "metric_value", "metric_recency"]]
                     .dropna()
                     .round(llmalert_metric_rounding)
                 )

--- a/anomstack/llm/completion.py
+++ b/anomstack/llm/completion.py
@@ -5,7 +5,6 @@ Some helper functions for interacting with the OpenAI API.
 import json
 import os
 import time
-from ctypes import DEFAULT_MODE
 
 import openai
 from dagster import get_dagster_logger

--- a/anomstack/llm/completion.py
+++ b/anomstack/llm/completion.py
@@ -5,9 +5,13 @@ Some helper functions for interacting with the OpenAI API.
 import json
 import os
 import time
+from ctypes import DEFAULT_MODE
 
 import openai
+from dagster import get_dagster_logger
 from openai import OpenAI
+
+DEFAULT_OPENAI_MODEL = "gpt-4o-mini"
 
 
 def get_completion(prompt: str, max_retries=5):
@@ -27,7 +31,10 @@ def get_completion(prompt: str, max_retries=5):
     """
 
     client = OpenAI(api_key=os.getenv("ANOMSTACK_OPENAI_KEY"))
-    openai_model = os.getenv("ANOMSTACK_OPENAI_MODEL", "gpt-3.5-turbo")
+    openai_model = os.getenv("ANOMSTACK_OPENAI_MODEL", DEFAULT_OPENAI_MODEL)
+
+    logger = get_dagster_logger()
+    logger.debug(f"using openai model: {openai_model}")
 
     messages = [{"role": "user", "content": prompt}]
 

--- a/metrics/defaults/sql/plot.sql
+++ b/metrics/defaults/sql/plot.sql
@@ -130,8 +130,8 @@ data_alerts AS (
     metric_value,
     metric_score,
     metric_score_smooth,
-    metric_alert,
-    metric_change
+    ifnull(metric_alert,0) as metric_alert,
+    ifnull(metric_change,0) as metric_change
   FROM data_smoothed
   WHERE metric_value_recency_rank <= {{ alert_max_n }}
 )

--- a/metrics/examples/python/python_ingest_simple/ingest.py
+++ b/metrics/examples/python/python_ingest_simple/ingest.py
@@ -5,16 +5,12 @@ def ingest():
     """
 
     import random
-    import time
 
     import pandas as pd
 
     # Define the number of metrics
     metrics = ["metric1", "metric2", "metric3", "metric4", "metric5"]
     metric_values = []
-
-    # Get current timestamp
-    current_timestamp = int(time.time())
 
     # Different anomaly types
     anomaly_types = ["spike", "drop", "plateau"]
@@ -24,7 +20,7 @@ def ingest():
     anomaly_type = (random.choice(anomaly_types)
                     if anomaly_chance <= 0.01 else None)
 
-    for metric in metrics:
+    for _ in metrics:
         if anomaly_type == "spike":
             # Generate a spike (e.g., a value significantly higher than normal)
             metric_value = random.uniform(15, 30)
@@ -46,7 +42,7 @@ def ingest():
     data = {
         "metric_name": metrics,
         "metric_value": metric_values,
-        "metric_timestamp": [current_timestamp] * len(metrics),
+        "metric_timestamp": pd.Timestamp.now(),
     }
     df = pd.DataFrame(data)
 

--- a/metrics/examples/python/python_ingest_simple/python_ingest_simple.yaml
+++ b/metrics/examples/python/python_ingest_simple/python_ingest_simple.yaml
@@ -5,5 +5,6 @@ alert_methods: "email,slack"
 ingest_cron_schedule: "*/2 * * * *"
 train_cron_schedule: "*/4 * * * *"
 score_cron_schedule: "*/3 * * * *"
+disable_llmalert: False
 ingest_fn: >
   {% include "./examples/python/python_ingest_simple/ingest.py" %}


### PR DESCRIPTION
This pull request includes several updates to improve the functionality and reliability of the system. The key changes involve updating the OpenAI model, adding a timeout to the SMTP connection, enhancing logging, and refining the handling of database locks and metric data.

### Updates to OpenAI Model and Logging:
* Updated the default OpenAI model to `gpt-4o-mini` in `.example.env` and `anomstack/llm/completion.py` files. This change includes adding a new constant `DEFAULT_OPENAI_MODEL` and logging the model being used. [[1]](diffhunk://#diff-9d7a2448bb252b3987e5cbb36d9d9818b1432313d86287acf8140d48ff911cdaL70-R71) [[2]](diffhunk://#diff-5bd8deb865f4959c80b827d76c0cd6b6de2bb446a8900175557af3355f23b8d0R10-R14) [[3]](diffhunk://#diff-5bd8deb865f4959c80b827d76c0cd6b6de2bb446a8900175557af3355f23b8d0L30-R36)

### Enhancements to Email and Database Handling:
* Added a timeout parameter to the SMTP connection in `anomstack/alerts/email.py` to improve email sending reliability.
* Improved the handling of database locks by splitting a long log message into two lines in `anomstack/external/sqlite/sqlite.py`.

### Data Processing and Metric Handling:
* Added `metric_timestamp` to the DataFrame in `anomstack/jobs/llmalert.py` to ensure all necessary metric data is included.
* Used `ifnull` function to handle null values in `metric_alert` and `metric_change` in `metrics/defaults/sql/plot.sql`.

### Miscellaneous Improvements:
* Removed unnecessary imports and updated the timestamp handling in `metrics/examples/python/python_ingest_simple/ingest.py`. [[1]](diffhunk://#diff-c0ac3e3c7bebd2e0b580e507e763209b5f3f85eeac642de9c5a1c668eb27d9cfL8-L18) [[2]](diffhunk://#diff-c0ac3e3c7bebd2e0b580e507e763209b5f3f85eeac642de9c5a1c668eb27d9cfL27-R23) [[3]](diffhunk://#diff-c0ac3e3c7bebd2e0b580e507e763209b5f3f85eeac642de9c5a1c668eb27d9cfL49-R45)
* Added a new configuration option `disable_llmalert` in `metrics/examples/python/python_ingest_simple/python_ingest_simple.yaml`.