### PR TITLE
Simplify llm

### DIFF
--- a/anomstack/alerts/asciiart.py
+++ b/anomstack/alerts/asciiart.py
@@ -527,16 +527,16 @@ def make_alert_message(
     )
     metric_timestamp_to = (
         df_alert_metric["metric_timestamp"].max().strftime("%Y-%m-%d %H:%M")
-    )
-    labels = (
-        np.where(df_alert_metric["metric_alert"] == 1, anomaly_symbol, normal_symbol)
-        + (df_alert_metric[score_col].round(2) * 100).astype("int").astype("str")
-        + "% "
-    )
-    data = zip(labels, x)
+    )    
     graph_title = f"{metric_name} ({metric_timestamp_from} to {metric_timestamp_to})"
     message = ""
     if ascii_graph:
+        labels = (
+            np.where(df_alert_metric["metric_alert"] == 1, anomaly_symbol, normal_symbol)
+            + (df_alert_metric[score_col].round(2) * 100).astype("int").astype("str")
+            + "% "
+        )
+        data = zip(labels, x)
         graph = Pyasciigraph(
             titlebar=" ", graphsymbol=graph_symbol, float_format=alert_float_format
         ).graph(graph_title, data)

--- a/anomstack/alerts/asciiart.py
+++ b/anomstack/alerts/asciiart.py
@@ -527,7 +527,7 @@ def make_alert_message(
     )
     metric_timestamp_to = (
         df_alert_metric["metric_timestamp"].max().strftime("%Y-%m-%d %H:%M")
-    )    
+    )
     graph_title = f"{metric_name} ({metric_timestamp_from} to {metric_timestamp_to})"
     message = ""
     if ascii_graph:

--- a/anomstack/alerts/asciiart.py
+++ b/anomstack/alerts/asciiart.py
@@ -532,8 +532,14 @@ def make_alert_message(
     message = ""
     if ascii_graph:
         labels = (
-            np.where(df_alert_metric["metric_alert"] == 1, anomaly_symbol, normal_symbol)
-            + (df_alert_metric[score_col].round(2) * 100).astype("int").astype("str")
+            np.where(
+                df_alert_metric["metric_alert"] == 1,
+                anomaly_symbol,
+                normal_symbol
+            )
+            + (df_alert_metric[score_col].round(2) * 100)
+            .astype("int")
+            .astype("str")
             + "% "
         )
         data = zip(labels, x)

--- a/anomstack/jobs/llmalert.py
+++ b/anomstack/jobs/llmalert.py
@@ -172,6 +172,7 @@ def build_llmalert_job(spec: dict) -> JobDefinition:
                             "metric_timestamp": metric_timestamp_max,
                             "alert_type": "llm",
                         },
+                        score_col="metric_score"
                     )
 
         llmalert(get_llmalert_data())

--- a/anomstack/jobs/llmalert.py
+++ b/anomstack/jobs/llmalert.py
@@ -105,11 +105,6 @@ def build_llmalert_job(spec: dict) -> JobDefinition:
                     .sort_values(by="metric_timestamp", ascending=True)
                     .reset_index(drop=True)
                 )
-                df_metric["metric_alert"] = df_metric["metric_alert"].fillna(0)
-                df_metric["metric_score"] = df_metric["metric_score"].fillna(0)
-                df_metric["metric_score_smooth"] = df_metric[
-                    "metric_score_smooth"
-                ].fillna(0)
                 df_metric = df_metric.dropna()
                 df_metric["metric_timestamp"] = pd.to_datetime(
                     df_metric["metric_timestamp"]

--- a/anomstack/jobs/llmalert.py
+++ b/anomstack/jobs/llmalert.py
@@ -126,9 +126,9 @@ def build_llmalert_job(spec: dict) -> JobDefinition:
                     df_metric[["metric_timestamp", "metric_value", "metric_recency"]]
                     .dropna()
                 )
-                df_prompt["metric_timestamp"] = df_metric["metric_timestamp"].dt.strftime(
-                    "%Y-%m-%d %H:%M:%S"
-                )
+                df_prompt["metric_timestamp"] = df_metric[
+                    "metric_timestamp"
+                ].dt.strftime("%Y-%m-%d %H:%M:%S")
                 df_prompt = df_prompt.set_index("metric_timestamp")
                 if llmalert_metric_rounding >= 0:
                     df_prompt = df_prompt.round(llmalert_metric_rounding)

--- a/metrics/defaults/defaults.yaml
+++ b/metrics/defaults/defaults.yaml
@@ -63,6 +63,7 @@ change_detect_last_n: 1 # number of last n observations to detect changes on.
 llmalert_recent_n: 5 # only llmalert on recent n so as to avoid continually alerting.
 llmalert_smooth_n: 0 # smooth metric value prior to sending to llm.
 llmalert_metric_rounding: -1 # round metric values to this number of decimal places.
+llmalert_metric_timestamp_max_days_ago: 1 # don't alert on metrics older than this.
 
 ############################################
 # schedules

--- a/metrics/defaults/defaults.yaml
+++ b/metrics/defaults/defaults.yaml
@@ -61,8 +61,8 @@ change_detect_last_n: 1 # number of last n observations to detect changes on.
 # llmalert params
 ############################################
 llmalert_recent_n: 5 # only llmalert on recent n so as to avoid continually alerting.
-llmalert_smooth_n: 3 # smooth metric value prior to sending to llm.
-llmalert_metric_rounding: 4 # round metric values to this number of decimal places.
+llmalert_smooth_n: 0 # smooth metric value prior to sending to llm.
+llmalert_metric_rounding: -1 # round metric values to this number of decimal places.
 
 ############################################
 # schedules
@@ -100,6 +100,9 @@ change_sql: >
 # default templated plot sql
 plot_sql: >
   {% include "./defaults/sql/plot.sql" %}
+# default templated llmalert sql
+llmalert_sql: >
+  {% include "./defaults/sql/llmalert.sql" %}
 # default templated dashboard sql
 dashboard_sql: >
   {% include "./defaults/sql/dashboard.sql" %}

--- a/metrics/defaults/python/prompt.py
+++ b/metrics/defaults/python/prompt.py
@@ -10,17 +10,12 @@ def make_prompt(df, llmalert_recent_n) -> str:
         str: A prompt for the user to check if there is an anomaly in the time series data.
     """
 
-    from tabulate import tabulate
-
-    text_representation = tabulate(
-        df.reset_index(), headers="keys", tablefmt="pipe", showindex=False
-    )
+    text_representation = df.to_markdown()
 
     prompt = f"""
-    Can you help me check if there is an anomaly in this time series data for this metric?
+    Can you help me check if there is an anomaly in the below time series data?
 
-    I am solely interested in looking at the last {llmalert_recent_n} observations (when metric_recency=recent).
-    If it looks like the more recent data may be anomalous in comparison to rest of the data (when metric_recency=baseline).
+    I am solely interested in looking at the last {llmalert_recent_n} observations (when metric_recency=recent) and if it looks like the more recent data may be anomalous in comparison to rest of the data (when metric_recency=baseline).
 
     Here are some questions to think about:
 
@@ -42,10 +37,6 @@ def make_prompt(df, llmalert_recent_n) -> str:
     - Focus only on how the most recent {llmalert_recent_n} observations and if they look anomalous or not in reference to the earlier baseline data.
     - The data comes from a pandas dataframe.
 
-    Here is the data (ordered in ascending order, so from oldest to newest (top to bottom)):
-
-    {text_representation}
-
     I need a yes or no answer as to if you think the recent data looks anomalous or not.
 
     Please also provide a description on why the metric looks anomalous if you think it does.
@@ -55,6 +46,10 @@ def make_prompt(df, llmalert_recent_n) -> str:
     Please think step by step and provide a description, along with evidence, of your thought process as you go through the data.
 
     Think globally too like a human would if they were eyeballing the data.
+
+    Here is the data (ordered in ascending order, so from oldest to newest (top to bottom)):
+
+    {text_representation}
     """
 
     return prompt

--- a/metrics/defaults/python/prompt.py
+++ b/metrics/defaults/python/prompt.py
@@ -17,11 +17,10 @@ def make_prompt(df, llmalert_recent_n) -> str:
     )
 
     prompt = f"""
-    You are a seasoned time series expert who has worked with time series data for many years and are very acomplished at spotting and explaining anomalies in time series data.
-
     Can you help me check if there is an anomaly in this time series data for this metric?
 
-    I am solely interested in looking at the last {llmalert_recent_n} observations (when metric_recency=recent) and if it looks like the more recent data may be anomalous or if it looks not all that much different from the rest of the data (metric_recency=baseline).
+    I am solely interested in looking at the last {llmalert_recent_n} observations (when metric_recency=recent).
+    If it looks like the more recent data may be anomalous in comparison to rest of the data (when metric_recency=baseline).
 
     Here are some questions to think about:
 
@@ -29,7 +28,6 @@ def make_prompt(df, llmalert_recent_n) -> str:
     - Are there any anomalies or outliers in the recent {llmalert_recent_n} observations of metric in df?
     - Can you identify any patterns or trends in the recent {llmalert_recent_n} values of the metric in df that could be indicative of an anomaly?
     - How does the distribution of the recent {llmalert_recent_n} values of the metric in df compare to the distribution of the entire dataset?
-    - Are there any changes in the mean, median, or standard deviation of the metric in the recent {llmalert_recent_n} observations that could be indicative of an anomaly?
     - Is there a sudden increase or decrease in the metric in the recent {llmalert_recent_n} observations?
     - Is there a change in the slope of the metric trend line in the recent {llmalert_recent_n} observations?
     - Are there any spikes or dips in the metric in the recent {llmalert_recent_n} observations?

--- a/metrics/defaults/sql/llmalert.sql
+++ b/metrics/defaults/sql/llmalert.sql
@@ -1,0 +1,149 @@
+/*
+Template for generating the input data for the plot job.
+*/
+
+WITH
+
+metric_value_data AS (
+  SELECT DISTINCT
+    metric_timestamp,
+    metric_batch,
+    metric_name,
+    AVG(metric_value) AS metric_value
+  FROM {{ table_key }}
+  WHERE metric_batch = '{{ metric_batch }}'
+    AND metric_type = 'metric'
+    AND DATE(metric_timestamp) >= DATE('now', '-{{ alert_metric_timestamp_max_days_ago }} day')
+  GROUP BY metric_timestamp, metric_batch, metric_name
+),
+
+metric_score_data AS (
+  SELECT DISTINCT
+    metric_timestamp,
+    metric_batch,
+    metric_name,
+    AVG(metric_value) AS metric_score
+  FROM {{ table_key }}
+  WHERE metric_batch = '{{ metric_batch }}'
+    AND metric_type = 'score'
+    AND DATE(metric_timestamp) >= DATE('now', '-{{ alert_metric_timestamp_max_days_ago }} day')
+  GROUP BY metric_timestamp, metric_batch, metric_name
+),
+
+metric_alert_data AS (
+  SELECT DISTINCT
+    metric_timestamp,
+    metric_batch,
+    metric_name,
+    MAX(metric_value) AS metric_alert
+  FROM {{ table_key }}
+  WHERE metric_batch = '{{ metric_batch }}'
+    AND metric_type = 'alert'
+    AND DATE(metric_timestamp) >= DATE('now', '-{{ alert_metric_timestamp_max_days_ago }} day')
+  GROUP BY metric_timestamp, metric_batch, metric_name
+),
+
+metric_change_data AS (
+  SELECT DISTINCT
+    metric_timestamp,
+    metric_batch,
+    metric_name,
+    MAX(metric_value) AS metric_change
+  FROM {{ table_key }}
+  WHERE metric_batch = '{{ metric_batch }}'
+    AND metric_type = 'change'
+    AND DATE(metric_timestamp) >= DATE('now', '-{{ change_metric_timestamp_max_days_ago }} day')
+  GROUP BY metric_timestamp, metric_batch, metric_name
+),
+
+metric_value_recency_ranked AS (
+  SELECT
+    metric_timestamp,
+    metric_batch,
+    metric_name,
+    metric_value,
+    ROW_NUMBER() OVER (PARTITION BY metric_name ORDER BY metric_timestamp DESC) AS metric_value_recency_rank
+  FROM metric_value_data
+),
+
+metric_score_recency_ranked AS (
+  SELECT
+    metric_timestamp,
+    metric_batch,
+    metric_name,
+    metric_score,
+    ROW_NUMBER() OVER (PARTITION BY metric_name ORDER BY metric_timestamp DESC) AS metric_score_recency_rank
+  FROM metric_score_data
+),
+
+data_ranked AS (
+  SELECT
+    m.metric_timestamp,
+    m.metric_batch,
+    m.metric_name,
+    m.metric_value,
+    s.metric_score,
+    a.metric_alert,
+    c.metric_change,
+    m.metric_value_recency_rank,
+    s.metric_score_recency_rank
+  FROM metric_value_recency_ranked m
+  LEFT JOIN metric_score_recency_ranked s
+    ON m.metric_batch = s.metric_batch
+    AND m.metric_name = s.metric_name
+    AND m.metric_timestamp = s.metric_timestamp
+  LEFT JOIN metric_alert_data a
+    ON m.metric_batch = a.metric_batch
+    AND m.metric_name = a.metric_name
+    AND m.metric_timestamp = a.metric_timestamp
+  LEFT JOIN metric_change_data c
+    ON m.metric_batch = c.metric_batch
+    AND m.metric_name = c.metric_name
+    AND m.metric_timestamp = c.metric_timestamp
+),
+
+data_smoothed AS (
+  SELECT
+    metric_timestamp,
+    metric_batch,
+    metric_name,
+    metric_value,
+    metric_score,
+    metric_alert,
+    metric_change,
+    metric_value_recency_rank,
+    metric_score_recency_rank,
+    -- Use a subquery or custom logic to compute the moving average for smoothing
+    (SELECT AVG(metric_score)
+     FROM data_ranked ds
+     WHERE ds.metric_batch = dr.metric_batch
+     AND ds.metric_name = dr.metric_name
+     AND ds.metric_score_recency_rank BETWEEN dr.metric_score_recency_rank - {{ alert_smooth_n }} AND dr.metric_score_recency_rank) AS metric_score_smooth
+  FROM data_ranked dr
+),
+
+data_alerts AS (
+  SELECT
+    metric_timestamp,
+    metric_batch,
+    metric_name,
+    metric_value,
+    metric_score,
+    metric_score_smooth,
+    ifnull(metric_alert,0) as metric_alert,
+    ifnull(metric_change,0) as metric_change
+  FROM data_smoothed
+  WHERE metric_value_recency_rank <= {{ alert_max_n }}
+)
+
+SELECT
+  metric_timestamp,
+  metric_batch,
+  metric_name,
+  metric_value,
+  metric_score,
+  metric_score_smooth,
+  metric_alert,
+  metric_change
+FROM data_alerts
+;

--- a/metrics/defaults/sql/llmalert.sql
+++ b/metrics/defaults/sql/llmalert.sql
@@ -1,149 +1,44 @@
 /*
-Template for generating the input data for the plot job.
+Template for generating the input data for the llmalert job.
 */
 
-WITH
+with
 
-metric_value_data AS (
-  SELECT DISTINCT
-    metric_timestamp,
-    metric_batch,
-    metric_name,
-    AVG(metric_value) AS metric_value
-  FROM {{ table_key }}
-  WHERE metric_batch = '{{ metric_batch }}'
-    AND metric_type = 'metric'
-    AND DATE(metric_timestamp) >= DATE('now', '-{{ alert_metric_timestamp_max_days_ago }} day')
-  GROUP BY metric_timestamp, metric_batch, metric_name
+metric_value_data as 
+(
+select distinct
+  metric_timestamp,
+  metric_batch,
+  metric_name,
+  avg(metric_value) AS metric_value
+from 
+  {{ table_key }}
+where
+  metric_batch = '{{ metric_batch }}'
+  and 
+  metric_type = 'metric'
+  and 
+  date(metric_timestamp) >= date('now', '-{{ llmalert_metric_timestamp_max_days_ago }} day')
+group by metric_timestamp, metric_batch, metric_name
 ),
 
-metric_score_data AS (
-  SELECT DISTINCT
-    metric_timestamp,
-    metric_batch,
-    metric_name,
-    AVG(metric_value) AS metric_score
-  FROM {{ table_key }}
-  WHERE metric_batch = '{{ metric_batch }}'
-    AND metric_type = 'score'
-    AND DATE(metric_timestamp) >= DATE('now', '-{{ alert_metric_timestamp_max_days_ago }} day')
-  GROUP BY metric_timestamp, metric_batch, metric_name
-),
-
-metric_alert_data AS (
-  SELECT DISTINCT
-    metric_timestamp,
-    metric_batch,
-    metric_name,
-    MAX(metric_value) AS metric_alert
-  FROM {{ table_key }}
-  WHERE metric_batch = '{{ metric_batch }}'
-    AND metric_type = 'alert'
-    AND DATE(metric_timestamp) >= DATE('now', '-{{ alert_metric_timestamp_max_days_ago }} day')
-  GROUP BY metric_timestamp, metric_batch, metric_name
-),
-
-metric_change_data AS (
-  SELECT DISTINCT
-    metric_timestamp,
-    metric_batch,
-    metric_name,
-    MAX(metric_value) AS metric_change
-  FROM {{ table_key }}
-  WHERE metric_batch = '{{ metric_batch }}'
-    AND metric_type = 'change'
-    AND DATE(metric_timestamp) >= DATE('now', '-{{ change_metric_timestamp_max_days_ago }} day')
-  GROUP BY metric_timestamp, metric_batch, metric_name
-),
-
-metric_value_recency_ranked AS (
-  SELECT
-    metric_timestamp,
-    metric_batch,
-    metric_name,
-    metric_value,
-    ROW_NUMBER() OVER (PARTITION BY metric_name ORDER BY metric_timestamp DESC) AS metric_value_recency_rank
-  FROM metric_value_data
-),
-
-metric_score_recency_ranked AS (
-  SELECT
-    metric_timestamp,
-    metric_batch,
-    metric_name,
-    metric_score,
-    ROW_NUMBER() OVER (PARTITION BY metric_name ORDER BY metric_timestamp DESC) AS metric_score_recency_rank
-  FROM metric_score_data
-),
-
-data_ranked AS (
-  SELECT
-    m.metric_timestamp,
-    m.metric_batch,
-    m.metric_name,
-    m.metric_value,
-    s.metric_score,
-    a.metric_alert,
-    c.metric_change,
-    m.metric_value_recency_rank,
-    s.metric_score_recency_rank
-  FROM metric_value_recency_ranked m
-  LEFT JOIN metric_score_recency_ranked s
-    ON m.metric_batch = s.metric_batch
-    AND m.metric_name = s.metric_name
-    AND m.metric_timestamp = s.metric_timestamp
-  LEFT JOIN metric_alert_data a
-    ON m.metric_batch = a.metric_batch
-    AND m.metric_name = a.metric_name
-    AND m.metric_timestamp = a.metric_timestamp
-  LEFT JOIN metric_change_data c
-    ON m.metric_batch = c.metric_batch
-    AND m.metric_name = c.metric_name
-    AND m.metric_timestamp = c.metric_timestamp
-),
-
-data_smoothed AS (
-  SELECT
-    metric_timestamp,
-    metric_batch,
-    metric_name,
-    metric_value,
-    metric_score,
-    metric_alert,
-    metric_change,
-    metric_value_recency_rank,
-    metric_score_recency_rank,
-    -- Use a subquery or custom logic to compute the moving average for smoothing
-    (SELECT AVG(metric_score)
-     FROM data_ranked ds
-     WHERE ds.metric_batch = dr.metric_batch
-     AND ds.metric_name = dr.metric_name
-     AND ds.metric_score_recency_rank BETWEEN dr.metric_score_recency_rank - {{ alert_smooth_n }} AND dr.metric_score_recency_rank) AS metric_score_smooth
-  FROM data_ranked dr
-),
-
-data_alerts AS (
-  SELECT
-    metric_timestamp,
-    metric_batch,
-    metric_name,
-    metric_value,
-    metric_score,
-    metric_score_smooth,
-    ifnull(metric_alert,0) as metric_alert,
-    ifnull(metric_change,0) as metric_change
-  FROM data_smoothed
-  WHERE metric_value_recency_rank <= {{ alert_max_n }}
-)
-
-SELECT
+metric_value_recency_ranked as 
+(
+select
   metric_timestamp,
   metric_batch,
   metric_name,
   metric_value,
-  metric_score,
-  metric_score_smooth,
-  metric_alert,
-  metric_change
-FROM data_alerts
+  row_number() over (partition by metric_name order by metric_timestamp desc) as metric_value_recency_rank
+from
+  metric_value_data
+)
+
+select
+  metric_timestamp,
+  metric_batch,
+  metric_name,
+  metric_value
+from 
+  metric_value_recency_ranked
 ;

--- a/metrics/defaults/sql/llmalert.sql
+++ b/metrics/defaults/sql/llmalert.sql
@@ -22,6 +22,42 @@ where
 group by metric_timestamp, metric_batch, metric_name
 ),
 
+metric_score_data as 
+(
+select distinct
+  metric_timestamp,
+  metric_batch,
+  metric_name,
+  avg(metric_value) AS metric_score
+from 
+  {{ table_key }}
+where
+  metric_batch = '{{ metric_batch }}'
+  and 
+  metric_type = 'score'
+  and 
+  date(metric_timestamp) >= date('now', '-{{ llmalert_metric_timestamp_max_days_ago }} day')
+group by metric_timestamp, metric_batch, metric_name
+),
+
+metric_alert_data as 
+(
+select distinct
+  metric_timestamp,
+  metric_batch,
+  metric_name,
+  avg(metric_value) AS metric_alert
+from 
+  {{ table_key }}
+where
+  metric_batch = '{{ metric_batch }}'
+  and 
+  metric_type = 'alert'
+  and 
+  date(metric_timestamp) >= date('now', '-{{ llmalert_metric_timestamp_max_days_ago }} day')
+group by metric_timestamp, metric_batch, metric_name
+),
+
 metric_value_recency_ranked as 
 (
 select
@@ -35,10 +71,28 @@ from
 )
 
 select
-  metric_timestamp,
-  metric_batch,
-  metric_name,
-  metric_value
+  m.metric_timestamp,
+  m.metric_batch,
+  m.metric_name,
+  m.metric_value,
+  ifnull(s.metric_score,0) as metric_score,
+  ifnull(a.metric_alert,0) as metric_alert
 from 
-  metric_value_recency_ranked
+  metric_value_recency_ranked m
+left join
+  metric_score_data s
+on
+  m.metric_timestamp = s.metric_timestamp
+  and
+  m.metric_batch = s.metric_batch
+  and
+  m.metric_name = s.metric_name
+left join
+  metric_alert_data a
+on
+  m.metric_timestamp = a.metric_timestamp
+  and
+  m.metric_batch = a.metric_batch
+  and
+  m.metric_name = a.metric_name
 ;

--- a/metrics/defaults/sql/llmalert.sql
+++ b/metrics/defaults/sql/llmalert.sql
@@ -4,61 +4,61 @@ Template for generating the input data for the llmalert job.
 
 with
 
-metric_value_data as 
+metric_value_data as
 (
 select distinct
   metric_timestamp,
   metric_batch,
   metric_name,
   avg(metric_value) AS metric_value
-from 
+from
   {{ table_key }}
 where
   metric_batch = '{{ metric_batch }}'
-  and 
+  and
   metric_type = 'metric'
-  and 
+  and
   date(metric_timestamp) >= date('now', '-{{ llmalert_metric_timestamp_max_days_ago }} day')
 group by metric_timestamp, metric_batch, metric_name
 ),
 
-metric_score_data as 
+metric_score_data as
 (
 select distinct
   metric_timestamp,
   metric_batch,
   metric_name,
   avg(metric_value) AS metric_score
-from 
+from
   {{ table_key }}
 where
   metric_batch = '{{ metric_batch }}'
-  and 
+  and
   metric_type = 'score'
-  and 
+  and
   date(metric_timestamp) >= date('now', '-{{ llmalert_metric_timestamp_max_days_ago }} day')
 group by metric_timestamp, metric_batch, metric_name
 ),
 
-metric_alert_data as 
+metric_alert_data as
 (
 select distinct
   metric_timestamp,
   metric_batch,
   metric_name,
   avg(metric_value) AS metric_alert
-from 
+from
   {{ table_key }}
 where
   metric_batch = '{{ metric_batch }}'
-  and 
+  and
   metric_type = 'alert'
-  and 
+  and
   date(metric_timestamp) >= date('now', '-{{ llmalert_metric_timestamp_max_days_ago }} day')
 group by metric_timestamp, metric_batch, metric_name
 ),
 
-metric_value_recency_ranked as 
+metric_value_recency_ranked as
 (
 select
   metric_timestamp,
@@ -77,7 +77,7 @@ select
   m.metric_value,
   ifnull(s.metric_score,0) as metric_score,
   ifnull(a.metric_alert,0) as metric_alert
-from 
+from
   metric_value_recency_ranked m
 left join
   metric_score_data s

--- a/requirements.compile
+++ b/requirements.compile
@@ -25,4 +25,3 @@ slack_sdk
 snowflake-connector-python[pandas]
 sqlglot
 streamlit
-tabulate

--- a/requirements.txt
+++ b/requirements.txt
@@ -506,9 +506,7 @@ streamlit==1.38.0
 structlog==24.4.0
     # via dagster
 tabulate==0.9.0
-    # via
-    #   -r requirements.compile
-    #   dagster
+    # via dagster
 tenacity==8.5.0
     # via
     #   plotly


### PR DESCRIPTION
This pull request includes several changes focused on improving the LLM alert system and refining the alert message generation. The most important changes involve modifying the alert configuration, updating SQL templates, and enhancing the prompt generation.

### Improvements to LLM alert system:

* [`anomstack/jobs/llmalert.py`](diffhunk://#diff-4e6d1eb6b2e6327eec1e17ee3c455309a8efdad5d40f86f4ff763639e763ce18L61-R61): Modified the rounding logic for `llmalert_metric_rounding` to allow for no rounding when set to -1, changed the SQL template reference to `llmalert_sql`, and adjusted the handling of missing values in `df_metric`. [[1]](diffhunk://#diff-4e6d1eb6b2e6327eec1e17ee3c455309a8efdad5d40f86f4ff763639e763ce18L61-R61) [[2]](diffhunk://#diff-4e6d1eb6b2e6327eec1e17ee3c455309a8efdad5d40f86f4ff763639e763ce18L80-R80) [[3]](diffhunk://#diff-4e6d1eb6b2e6327eec1e17ee3c455309a8efdad5d40f86f4ff763639e763ce18L108-L112) [[4]](diffhunk://#diff-4e6d1eb6b2e6327eec1e17ee3c455309a8efdad5d40f86f4ff763639e763ce18L133-R134) [[5]](diffhunk://#diff-4e6d1eb6b2e6327eec1e17ee3c455309a8efdad5d40f86f4ff763639e763ce18R175)

* [`metrics/defaults/defaults.yaml`](diffhunk://#diff-87b1ac24a54e3a83a9a0c5caddafbc2b2e4c8df4cee00ebfe10c73968112b2f7L64-R66): Updated default values for `llmalert_metric_rounding`, `llmalert_smooth_n`, and added a new parameter `llmalert_metric_timestamp_max_days_ago` to avoid alerting on older metrics. [[1]](diffhunk://#diff-87b1ac24a54e3a83a9a0c5caddafbc2b2e4c8df4cee00ebfe10c73968112b2f7L64-R66) [[2]](diffhunk://#diff-87b1ac24a54e3a83a9a0c5caddafbc2b2e4c8df4cee00ebfe10c73968112b2f7R104-R106)

* [`metrics/defaults/sql/llmalert.sql`](diffhunk://#diff-f60d044add5021886809cd66899f2514b560594c1b85fde3d91414079ef06359R1-R98): Added a new SQL template for generating input data for the LLM alert job, including separate queries for metric values, scores, and alerts.

### Enhancements to alert message generation:

* [`anomstack/alerts/asciiart.py`](diffhunk://#diff-abeccbb7cd589f22c24b13cbd2e4a43f7c66554f9f8ff11dadd266c5bc406c0dR531-L539): Refactored the `make_alert_message` function to improve the title and message generation logic for ASCII graphs.

* [`metrics/defaults/python/prompt.py`](diffhunk://#diff-137335d377df5789b8928bc4600d5867045628298b6ff270316a973b41f6f229L13-L32): Simplified the prompt generation by using `df.to_markdown()` instead of `tabulate` and restructured the prompt text for clarity. [[1]](diffhunk://#diff-137335d377df5789b8928bc4600d5867045628298b6ff270316a973b41f6f229L13-L32) [[2]](diffhunk://#diff-137335d377df5789b8928bc4600d5867045628298b6ff270316a973b41f6f229L47-L50) [[3]](diffhunk://#diff-137335d377df5789b8928bc4600d5867045628298b6ff270316a973b41f6f229R49-R52)

### Dependency updates:

* [`requirements.compile`](diffhunk://#diff-73116cc8c8711ac4eb754dbe3d48b7c50bddf945ea27c4f5030ae921a122f99bL28): Removed the `tabulate` dependency as it is no longer needed for prompt generation.