### PR TITLE
Add train alert score exclude metrics

### DIFF
--- a/metrics/defaults/defaults.yaml
+++ b/metrics/defaults/defaults.yaml
@@ -28,6 +28,12 @@ preprocess_params:
   lags_n: 5 # how many lags to include in feature vector.
   freq: null # how often to resample for different aggregation levels than ingested at. Default of null means no resampling.
   freq_agg: 'mean' # default aggregation function to use for resampling if freq != None.
+# optional list of metrics to exclude from training.
+# train_exclude_metrics:
+#   - 'dummy_exclude_metric'
+# optional list of metrics to exclude from scoring.
+# score_exclude_metrics:
+#   - 'dummy_exclude_metric'
 
 ############################################
 # alert params
@@ -40,6 +46,9 @@ alert_max_n: 250 # max n to include and plot in an alert.
 alert_smooth_n: 3 # smooth anomaly score over rolling n to avoid being too trigger happy.
 alert_snooze_n: 3 # snooze alerts for n periods after an alert.
 alert_threshold: 0.8 # threshold for smoothed anomaly score above which to alert on.
+# optional list of metrics to exclude from alerts.
+# alert_exclude_metrics:
+#   - 'dummy_exclude_metric'
 
 ############################################
 # change detection params

--- a/metrics/defaults/sql/alerts.sql
+++ b/metrics/defaults/sql/alerts.sql
@@ -21,6 +21,11 @@ where
   metric_type = 'metric'
   and 
   date(metric_timestamp) >= date('now', '-{{ alert_metric_timestamp_max_days_ago }} day')
+  {% if alert_exclude_metrics is defined %}
+  and
+  -- Exclude the specified metrics
+  metric_name not in ({{ ','.join(alert_exclude_metrics) }})
+  {% endif %}
 group by metric_timestamp, metric_batch, metric_name
 ),
 

--- a/metrics/defaults/sql/score.sql
+++ b/metrics/defaults/sql/score.sql
@@ -4,7 +4,7 @@ Template for generating input metric data for scoring.
 
 with
 
-data as 
+data as
 (
 select
   metric_timestamp,
@@ -12,11 +12,11 @@ select
   metric_name,
   avg(case when metric_type = 'metric' then metric_value else null end) as metric_value,
   avg(case when metric_type = 'score' then metric_value else null end) as metric_score
-from 
+from
   {{ table_key }}
-where 
+where
   metric_batch = '{{ metric_batch }}'
-  and 
+  and
   metric_type in ('metric', 'score')
   {% if score_exclude_metrics is defined %}
   and
@@ -34,7 +34,7 @@ select
   metric_value,
   metric_score,
   row_number() over (partition by metric_name order by metric_timestamp desc) as metric_recency_rank
-from 
+from
   data
 )
 
@@ -44,7 +44,7 @@ select
   metric_name,
   metric_value,
   metric_score
-from 
+from
   data_ranked
 where
   -- Limit to the most recent {{ score_max_n }} records

--- a/metrics/defaults/sql/score.sql
+++ b/metrics/defaults/sql/score.sql
@@ -2,40 +2,51 @@
 Template for generating input metric data for scoring.
 */
 
-WITH
+with
 
-data AS (
-  SELECT
-    metric_timestamp,
-    metric_batch,
-    metric_name,
-    AVG(CASE WHEN metric_type = 'metric' THEN metric_value ELSE NULL END) AS metric_value,
-    AVG(CASE WHEN metric_type = 'score' THEN metric_value ELSE NULL END) AS metric_score
-  FROM {{ table_key }}
-  WHERE metric_batch = '{{ metric_batch }}'
-    AND metric_type IN ('metric', 'score')
-  GROUP BY metric_timestamp, metric_batch, metric_name
+data as 
+(
+select
+  metric_timestamp,
+  metric_batch,
+  metric_name,
+  avg(case when metric_type = 'metric' then metric_value else null end) as metric_value,
+  avg(case when metric_type = 'score' then metric_value else null end) as metric_score
+from 
+  {{ table_key }}
+where 
+  metric_batch = '{{ metric_batch }}'
+  and 
+  metric_type in ('metric', 'score')
+  {% if score_exclude_metrics is defined %}
+  and
+  -- Exclude the specified metrics
+  metric_name not in ({{ ','.join(score_exclude_metrics) }})
+  {% endif %}
+group by metric_timestamp, metric_batch, metric_name
 ),
 
-data_ranked AS (
-  SELECT
-    metric_timestamp,
-    metric_batch,
-    metric_name,
-    metric_value,
-    metric_score,
-    ROW_NUMBER() OVER (PARTITION BY metric_name ORDER BY metric_timestamp DESC) AS metric_recency_rank
-  FROM data
+data_ranked as (
+select
+  metric_timestamp,
+  metric_batch,
+  metric_name,
+  metric_value,
+  metric_score,
+  row_number() over (partition by metric_name order by metric_timestamp desc) as metric_recency_rank
+from 
+  data
 )
 
-SELECT
+select
   metric_timestamp,
   metric_batch,
   metric_name,
   metric_value,
   metric_score
-FROM data_ranked
-WHERE
+from 
+  data_ranked
+where
   -- Limit to the most recent {{ score_max_n }} records
   metric_recency_rank <= {{ score_max_n }}
 ;

--- a/metrics/defaults/sql/train.sql
+++ b/metrics/defaults/sql/train.sql
@@ -4,17 +4,17 @@ Template for generating the input data for the train job.
 
 with
 
-data as 
+data as
 (
 select
   metric_timestamp,
   metric_name,
   avg(metric_value) AS metric_value
-from 
+from
   {{ table_key }}
-where 
+where
   metric_batch = '{{ metric_batch }}'
-  and 
+  and
   metric_type = 'metric'
   {% if train_exclude_metrics is defined %}
   and
@@ -24,18 +24,18 @@ where
 group by metric_timestamp, metric_name
 ),
 
-data_ranked as 
+data_ranked as
 (
 select
   *,
   row_number() over (partition by metric_name order by metric_timestamp desc) as metric_recency_rank
-from 
+from
   data
 )
 
 select
   *
-from 
+from
   data_ranked
 where
   -- Only include the most recent {{ train_max_n }} records

--- a/metrics/defaults/sql/train.sql
+++ b/metrics/defaults/sql/train.sql
@@ -2,33 +2,45 @@
 Template for generating the input data for the train job.
 */
 
-WITH
+with
 
-data AS (
-  SELECT
-    metric_timestamp,
-    metric_name,
-    AVG(metric_value) AS metric_value
-  FROM {{ table_key }}
-  WHERE metric_batch = '{{ metric_batch }}'
-    AND metric_type = 'metric'
-  GROUP BY metric_timestamp, metric_name
+data as 
+(
+select
+  metric_timestamp,
+  metric_name,
+  avg(metric_value) AS metric_value
+from 
+  {{ table_key }}
+where 
+  metric_batch = '{{ metric_batch }}'
+  and 
+  metric_type = 'metric'
+  {% if train_exclude_metrics is defined %}
+  and
+  -- Exclude the specified metrics
+  metric_name not in ({{ ','.join(train_exclude_metrics) }})
+  {% endif %}
+group by metric_timestamp, metric_name
 ),
 
-data_ranked AS (
-  SELECT
-    *,
-    ROW_NUMBER() OVER (PARTITION BY metric_name ORDER BY metric_timestamp DESC) AS metric_recency_rank
-  FROM data
+data_ranked as 
+(
+select
+  *,
+  row_number() over (partition by metric_name order by metric_timestamp desc) as metric_recency_rank
+from 
+  data
 )
 
-SELECT
+select
   *
-FROM data_ranked
-WHERE
+from 
+  data_ranked
+where
   -- Only include the most recent {{ train_max_n }} records
   metric_recency_rank <= {{ train_max_n }}
-  AND
+  and
   -- Must be at least {{ train_min_n }} records
   metric_recency_rank >= {{ train_min_n }}
 ;

--- a/metrics/examples/eirgrid/eirgrid.yaml
+++ b/metrics/examples/eirgrid/eirgrid.yaml
@@ -11,5 +11,17 @@ plot_cron_schedule: "*/140 * * * *"
 alert_always: False
 alert_methods: "email,slack"
 disable_llmalert: False
+train_exclude_metrics:
+  - eirgrid_demand_forecast_value
+  - eirgrid_wind_fcast
+alert_exclude_metrics:
+  - eirgrid_demand_forecast_value
+  - eirgrid_wind_fcast
+score_exclude_metrics:
+  - eirgrid_demand_forecast_value
+  - eirgrid_wind_fcast
+change_exclude_metrics:
+  - eirgrid_demand_forecast_value
+  - eirgrid_wind_fcast
 ingest_fn: >
   {% include "./examples/eirgrid/eirgrid.py" %}


### PR DESCRIPTION
This pull request introduces several enhancements to the metrics processing system, primarily focusing on excluding specific metrics from various stages such as training, scoring, and alerting. The most important changes include updates to the configuration files and SQL templates to support these exclusions.

### Configuration Updates:

* [`metrics/defaults/defaults.yaml`](diffhunk://#diff-87b1ac24a54e3a83a9a0c5caddafbc2b2e4c8df4cee00ebfe10c73968112b2f7R31-R36): Added optional lists for excluding metrics from training, scoring, and alerts. [[1]](diffhunk://#diff-87b1ac24a54e3a83a9a0c5caddafbc2b2e4c8df4cee00ebfe10c73968112b2f7R31-R36) [[2]](diffhunk://#diff-87b1ac24a54e3a83a9a0c5caddafbc2b2e4c8df4cee00ebfe10c73968112b2f7R49-R51)

### SQL Template Modifications:

* [`metrics/defaults/sql/alerts.sql`](diffhunk://#diff-722ec27fd20334c84a649c0ef8a19b95b3a190d03d148562c1b277574dbe9bfbR24-R28): Modified the SQL to exclude specified metrics from alerting if defined.
* [`metrics/defaults/sql/score.sql`](diffhunk://#diff-91797e236a7f7b1539658334bbc967aec9d74571d8d6b53ad76ee9b8fc96e97aL5-R49): Updated the SQL to exclude specified metrics from scoring if defined.
* [`metrics/defaults/sql/train.sql`](diffhunk://#diff-9eedbfa5f858c367cc19238be823909eaa90801239eee01d41c5ae7dd0306abfL5-R43): Enhanced the SQL to exclude specified metrics from training if defined.

### Example Configuration:

* [`metrics/examples/eirgrid/eirgrid.yaml`](diffhunk://#diff-f38e4c8b529a491a4e833966ec011072d7d3b3fa6104ec07ec68fa58f14ac472R14-R25): Added specific metrics to be excluded from training, scoring, alerts, and change detection for the EirGrid example configuration.