### PR TITLE
Bump version to 0.0.14 in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ def read_requirements():
 
 setup(
     name='anomstack',
-    version='0.0.13',
+    version='0.0.14',
     packages=find_packages(),
     install_requires=read_requirements()
 )


### PR DESCRIPTION
This pull request includes a version update for the `anomstack` package in the `setup.py` file. The version has been incremented from `0.0.13` to `0.0.14`.

* [`setup.py`](diffhunk://#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7L11-R11): Updated the package version from `0.0.13` to `0.0.14`.