### PR TITLE
bump version to 0.0.15

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ def read_requirements():
 
 setup(
     name='anomstack',
-    version='0.0.14',
+    version='0.0.15',
     packages=find_packages(),
     install_requires=read_requirements()
 )


### PR DESCRIPTION
This pull request includes a small change to the `setup.py` file. The version of the `anomstack` package has been incremented from `0.0.14` to `0.0.15` to reflect updates or bug fixes.

* [`setup.py`](diffhunk://#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7L11-R11): Updated the version from `0.0.14` to `0.0.15`.