### PR TITLE
Optimize SQL queries

### DIFF
--- a/metrics/defaults/sql/alerts.sql
+++ b/metrics/defaults/sql/alerts.sql
@@ -20,7 +20,7 @@ where
   and
   metric_type = 'metric'
   and
-  date(metric_timestamp) >= date('now', '-{{ alert_metric_timestamp_max_days_ago }} day')
+  metric_timestamp >= date('now', '-{{ alert_metric_timestamp_max_days_ago }} day')
   {% if alert_exclude_metrics is defined %}
   and
   -- Exclude the specified metrics
@@ -43,7 +43,7 @@ where
   and
   metric_type = 'score'
   and
-  date(metric_timestamp) >= date('now', '-{{ alert_metric_timestamp_max_days_ago }} day')
+  metric_timestamp >= date('now', '-{{ alert_metric_timestamp_max_days_ago }} day')
 group by metric_timestamp, metric_batch, metric_name
 ),
 
@@ -61,7 +61,7 @@ where
   and
   metric_type = 'alert'
   and
-  date(metric_timestamp) >= date('now', '-{{ alert_metric_timestamp_max_days_ago }} day')
+  metric_timestamp >= date('now', '-{{ alert_metric_timestamp_max_days_ago }} day')
 group by metric_timestamp, metric_batch, metric_name
 ),
 

--- a/metrics/defaults/sql/change.sql
+++ b/metrics/defaults/sql/change.sql
@@ -21,7 +21,7 @@ where
   metric_type = 'metric'
   and
   -- Filter to the last {{ change_metric_timestamp_max_days_ago }} days
-  date(metric_timestamp) >= date('now', '-{{ change_metric_timestamp_max_days_ago }} day')
+  metric_timestamp >= date('now', '-{{ change_metric_timestamp_max_days_ago }} day')
   {% if change_include_metrics is defined %}
   and
   -- Include only the specified metrics
@@ -51,7 +51,7 @@ where
   metric_type = 'change'
   and
   -- Filter to the last {{ change_metric_timestamp_max_days_ago }} days
-  date(metric_timestamp) >= date('now', '-{{ change_metric_timestamp_max_days_ago }} day')
+  metric_timestamp >= date('now', '-{{ change_metric_timestamp_max_days_ago }} day')
   {% if change_include_metrics is defined %}
   and
   -- Include only the specified metrics

--- a/metrics/defaults/sql/dashboard.sql
+++ b/metrics/defaults/sql/dashboard.sql
@@ -13,7 +13,7 @@ metric_value_data AS (
   FROM {{ table_key }}
   WHERE metric_batch = '{{ metric_batch }}'
     AND metric_type = 'metric'
-    AND DATE(metric_timestamp) >= DATE('now', '-{{ alert_metric_timestamp_max_days_ago }} day')
+    AND metric_timestamp >= DATE('now', '-{{ alert_metric_timestamp_max_days_ago }} day')
   GROUP BY metric_timestamp, metric_batch, metric_name
 ),
 
@@ -26,7 +26,7 @@ metric_score_data AS (
   FROM {{ table_key }}
   WHERE metric_batch = '{{ metric_batch }}'
     AND metric_type = 'score'
-    AND DATE(metric_timestamp) >= DATE('now', '-{{ alert_metric_timestamp_max_days_ago }} day')
+    AND metric_timestamp >= DATE('now', '-{{ alert_metric_timestamp_max_days_ago }} day')
   GROUP BY metric_timestamp, metric_batch, metric_name
 ),
 
@@ -39,7 +39,7 @@ metric_alert_data AS (
   FROM {{ table_key }}
   WHERE metric_batch = '{{ metric_batch }}'
     AND metric_type = 'alert'
-    AND DATE(metric_timestamp) >= DATE('now', '-{{ alert_metric_timestamp_max_days_ago }} day')
+    AND metric_timestamp >= DATE('now', '-{{ alert_metric_timestamp_max_days_ago }} day')
   GROUP BY metric_timestamp, metric_batch, metric_name
 ),
 
@@ -52,7 +52,7 @@ metric_change_data AS (
   FROM {{ table_key }}
   WHERE metric_batch = '{{ metric_batch }}'
     AND metric_type = 'change'
-    AND DATE(metric_timestamp) >= DATE('now', '-{{ change_metric_timestamp_max_days_ago }} day')
+    AND metric_timestamp >= DATE('now', '-{{ change_metric_timestamp_max_days_ago }} day')
   GROUP BY metric_timestamp, metric_batch, metric_name
 ),
 

--- a/metrics/defaults/sql/llmalert.sql
+++ b/metrics/defaults/sql/llmalert.sql
@@ -18,7 +18,7 @@ where
   and
   metric_type = 'metric'
   and
-  date(metric_timestamp) >= date('now', '-{{ llmalert_metric_timestamp_max_days_ago }} day')
+  metric_timestamp >= date('now', '-{{ llmalert_metric_timestamp_max_days_ago }} day')
 group by metric_timestamp, metric_batch, metric_name
 ),
 
@@ -36,7 +36,7 @@ where
   and
   metric_type = 'score'
   and
-  date(metric_timestamp) >= date('now', '-{{ llmalert_metric_timestamp_max_days_ago }} day')
+  metric_timestamp >= date('now', '-{{ llmalert_metric_timestamp_max_days_ago }} day')
 group by metric_timestamp, metric_batch, metric_name
 ),
 
@@ -54,7 +54,7 @@ where
   and
   metric_type = 'alert'
   and
-  date(metric_timestamp) >= date('now', '-{{ llmalert_metric_timestamp_max_days_ago }} day')
+  metric_timestamp >= date('now', '-{{ llmalert_metric_timestamp_max_days_ago }} day')
 group by metric_timestamp, metric_batch, metric_name
 ),
 

--- a/metrics/defaults/sql/plot.sql
+++ b/metrics/defaults/sql/plot.sql
@@ -13,7 +13,7 @@ metric_value_data AS (
   FROM {{ table_key }}
   WHERE metric_batch = '{{ metric_batch }}'
     AND metric_type = 'metric'
-    AND DATE(metric_timestamp) >= DATE('now', '-{{ alert_metric_timestamp_max_days_ago }} day')
+    AND metric_timestamp >= DATE('now', '-{{ alert_metric_timestamp_max_days_ago }} day')
   GROUP BY metric_timestamp, metric_batch, metric_name
 ),
 
@@ -26,7 +26,7 @@ metric_score_data AS (
   FROM {{ table_key }}
   WHERE metric_batch = '{{ metric_batch }}'
     AND metric_type = 'score'
-    AND DATE(metric_timestamp) >= DATE('now', '-{{ alert_metric_timestamp_max_days_ago }} day')
+    AND metric_timestamp >= DATE('now', '-{{ alert_metric_timestamp_max_days_ago }} day')
   GROUP BY metric_timestamp, metric_batch, metric_name
 ),
 
@@ -39,7 +39,7 @@ metric_alert_data AS (
   FROM {{ table_key }}
   WHERE metric_batch = '{{ metric_batch }}'
     AND metric_type = 'alert'
-    AND DATE(metric_timestamp) >= DATE('now', '-{{ alert_metric_timestamp_max_days_ago }} day')
+    AND metric_timestamp >= DATE('now', '-{{ alert_metric_timestamp_max_days_ago }} day')
   GROUP BY metric_timestamp, metric_batch, metric_name
 ),
 
@@ -52,7 +52,7 @@ metric_change_data AS (
   FROM {{ table_key }}
   WHERE metric_batch = '{{ metric_batch }}'
     AND metric_type = 'change'
-    AND DATE(metric_timestamp) >= DATE('now', '-{{ change_metric_timestamp_max_days_ago }} day')
+    AND metric_timestamp >= DATE('now', '-{{ change_metric_timestamp_max_days_ago }} day')
   GROUP BY metric_timestamp, metric_batch, metric_name
 ),
 

--- a/metrics/defaults/sql/summary.sql
+++ b/metrics/defaults/sql/summary.sql
@@ -8,7 +8,7 @@ SELECT
 FROM {{ table_key }}
 WHERE
   -- Limit to the last {{ summary_metric_timestamp_max_days_ago }} days
-  DATE(metric_timestamp) >= DATE('now', '-{{ summary_metric_timestamp_max_days_ago }} day')
+  metric_timestamp >= DATE('now', '-{{ summary_metric_timestamp_max_days_ago }} day')
 GROUP BY metric_batch, metric_name
 ORDER BY n_alert DESC
 ;


### PR DESCRIPTION
This pull request includes changes to multiple SQL files to standardize the filtering of `metric_timestamp` without converting it to a date. The changes ensure consistency and potentially improve performance by removing unnecessary date conversions.

Changes to SQL files:

* [`metrics/defaults/sql/alerts.sql`](diffhunk://#diff-722ec27fd20334c84a649c0ef8a19b95b3a190d03d148562c1b277574dbe9bfbL23-R23): Updated the `where` clause to filter `metric_timestamp` directly instead of converting it to a date. [[1]](diffhunk://#diff-722ec27fd20334c84a649c0ef8a19b95b3a190d03d148562c1b277574dbe9bfbL23-R23) [[2]](diffhunk://#diff-722ec27fd20334c84a649c0ef8a19b95b3a190d03d148562c1b277574dbe9bfbL46-R46) [[3]](diffhunk://#diff-722ec27fd20334c84a649c0ef8a19b95b3a190d03d148562c1b277574dbe9bfbL64-R64)
* [`metrics/defaults/sql/change.sql`](diffhunk://#diff-930a2ae9fa8dee5df1ce55b087a4ce10ed5b81a4365ec37725eb1b52781b50c4L24-R24): Updated the `where` clause to filter `metric_timestamp` directly instead of converting it to a date. [[1]](diffhunk://#diff-930a2ae9fa8dee5df1ce55b087a4ce10ed5b81a4365ec37725eb1b52781b50c4L24-R24) [[2]](diffhunk://#diff-930a2ae9fa8dee5df1ce55b087a4ce10ed5b81a4365ec37725eb1b52781b50c4L54-R54)
* [`metrics/defaults/sql/dashboard.sql`](diffhunk://#diff-dd5a430f2d5e74434204c2f1eed35c0852914dde831aa2b2fa25fec7cc5d28c4L16-R16): Updated multiple `metric_*_data AS` sections to filter `metric_timestamp` directly instead of converting it to a date. [[1]](diffhunk://#diff-dd5a430f2d5e74434204c2f1eed35c0852914dde831aa2b2fa25fec7cc5d28c4L16-R16) [[2]](diffhunk://#diff-dd5a430f2d5e74434204c2f1eed35c0852914dde831aa2b2fa25fec7cc5d28c4L29-R29) [[3]](diffhunk://#diff-dd5a430f2d5e74434204c2f1eed35c0852914dde831aa2b2fa25fec7cc5d28c4L42-R42) [[4]](diffhunk://#diff-dd5a430f2d5e74434204c2f1eed35c0852914dde831aa2b2fa25fec7cc5d28c4L55-R55)
* [`metrics/defaults/sql/llmalert.sql`](diffhunk://#diff-f60d044add5021886809cd66899f2514b560594c1b85fde3d91414079ef06359L21-R21): Updated the `where` clause to filter `metric_timestamp` directly instead of converting it to a date. [[1]](diffhunk://#diff-f60d044add5021886809cd66899f2514b560594c1b85fde3d91414079ef06359L21-R21) [[2]](diffhunk://#diff-f60d044add5021886809cd66899f2514b560594c1b85fde3d91414079ef06359L39-R39) [[3]](diffhunk://#diff-f60d044add5021886809cd66899f2514b560594c1b85fde3d91414079ef06359L57-R57)
* [`metrics/defaults/sql/plot.sql`](diffhunk://#diff-c4ba9e4ad9b94fe75e28f1d0dca65512de44a66c9271b861c987f1b8e7c3c13aL16-R16): Updated multiple `metric_*_data AS` sections to filter `metric_timestamp` directly instead of converting it to a date. [[1]](diffhunk://#diff-c4ba9e4ad9b94fe75e28f1d0dca65512de44a66c9271b861c987f1b8e7c3c13aL16-R16) [[2]](diffhunk://#diff-c4ba9e4ad9b94fe75e28f1d0dca65512de44a66c9271b861c987f1b8e7c3c13aL29-R29) [[3]](diffhunk://#diff-c4ba9e4ad9b94fe75e28f1d0dca65512de44a66c9271b861c987f1b8e7c3c13aL42-R42) [[4]](diffhunk://#diff-c4ba9e4ad9b94fe75e28f1d0dca65512de44a66c9271b861c987f1b8e7c3c13aL55-R55)
* [`metrics/defaults/sql/summary.sql`](diffhunk://#diff-7f1ebbe1fc824e74f933d38500330e3d64f28111924e5959f34b2393e9bcc307L11-R11): Updated the `SELECT` statement to filter `metric_timestamp` directly instead of converting it to a date.