### PR TITLE
Optimize SQL a little more

### DIFF
--- a/metrics/defaults/defaults.yaml
+++ b/metrics/defaults/defaults.yaml
@@ -20,8 +20,10 @@ model_configs:
       contamination: 0.01
 model_combination_method: 'mean' # method to combine model scores, 'mean', 'min' or 'max'.
 train_max_n: 2500 # max number of observations for training a model.
+train_metric_timestamp_max_days_ago: 30
 train_min_n: 14 # min number of observations for training a model.
 score_max_n: 25 # max n to pull for scoring to avoid pulling more than needed.
+score_metric_timestamp_max_days_ago: 7
 preprocess_params:
   diff_n: 1 # 1 will use diff, 0 will use raw metric values.
   smooth_n: 3 # how much smoothing to apply in preprocessing.

--- a/metrics/defaults/sql/score.sql
+++ b/metrics/defaults/sql/score.sql
@@ -18,6 +18,8 @@ where
   metric_batch = '{{ metric_batch }}'
   and
   metric_type in ('metric', 'score')
+  and
+  metric_timestamp >= date('now', '-{{ score_metric_timestamp_max_days_ago }} day')
   {% if score_exclude_metrics is defined %}
   and
   -- Exclude the specified metrics

--- a/metrics/defaults/sql/train.sql
+++ b/metrics/defaults/sql/train.sql
@@ -16,6 +16,8 @@ where
   metric_batch = '{{ metric_batch }}'
   and
   metric_type = 'metric'
+  and
+  metric_timestamp >= date('now', '-{{ train_metric_timestamp_max_days_ago }} day')
   {% if train_exclude_metrics is defined %}
   and
   -- Exclude the specified metrics


### PR DESCRIPTION
This pull request includes changes to the `metrics/defaults` configuration and SQL files to introduce a maximum age for metric timestamps when training and scoring models. The most important changes are summarized below:

Configuration updates:
* [`metrics/defaults/defaults.yaml`](diffhunk://#diff-87b1ac24a54e3a83a9a0c5caddafbc2b2e4c8df4cee00ebfe10c73968112b2f7R23-R26): Added `train_metric_timestamp_max_days_ago` and `score_metric_timestamp_max_days_ago` parameters to limit the age of metric data used for training and scoring.

SQL updates:
* [`metrics/defaults/sql/score.sql`](diffhunk://#diff-91797e236a7f7b1539658334bbc967aec9d74571d8d6b53ad76ee9b8fc96e97aR21-R22): Updated the `where` clause to filter out metric data older than the specified `score_metric_timestamp_max_days_ago` parameter.
* [`metrics/defaults/sql/train.sql`](diffhunk://#diff-9eedbfa5f858c367cc19238be823909eaa90801239eee01d41c5ae7dd0306abfR19-R20): Updated the `where` clause to filter out metric data older than the specified `train_metric_timestamp_max_days_ago` parameter.