### PR TITLE
Fixtests

### DIFF
--- a/.replit
+++ b/.replit
@@ -5,12 +5,12 @@ hidden = [".config", ".pytest_cache"]
 channel = "stable-24_05"
 
 [[ports]]
-localPort = 8080
-externalPort = 80
-
-[[ports]]
 localPort = 3000
 externalPort = 3000
+
+[[ports]]
+localPort = 8080
+externalPort = 80
 
 [workflows]
 runButton = "Dashboard Only"

--- a/tests/test_duckdb.py
+++ b/tests/test_duckdb.py
@@ -96,7 +96,10 @@ class TestReadSqlDuckdb:
         expected_df = pd.DataFrame({'result': [42]})
         mock_query.return_value.df.return_value = expected_df
         
-        with patch.dict(os.environ, {'ANOMSTACK_DUCKDB_PATH': 'md:my_db'}, clear=True):
+        with patch.dict(os.environ, {'ANOMSTACK_DUCKDB_PATH': 'md:my_db'}, clear=False):
+            # Ensure ANOMSTACK_MOTHERDUCK_TOKEN is not set
+            if 'ANOMSTACK_MOTHERDUCK_TOKEN' in os.environ:
+                del os.environ['ANOMSTACK_MOTHERDUCK_TOKEN']
             # Call function
             result = read_sql_duckdb("SELECT 42 as result")
             

--- a/tests/test_duckdb.py
+++ b/tests/test_duckdb.py
@@ -220,8 +220,8 @@ class TestSaveDfDuckdb:
         mock_conn = MagicMock()
         mock_connect.return_value = mock_conn
         
-        # First INSERT fails, then CREATE SCHEMA and CREATE TABLE succeed
-        mock_query.side_effect = [Exception("Table doesn't exist"), None, None]
+        # First CREATE SCHEMA succeeds, then INSERT fails, then CREATE TABLE succeeds
+        mock_query.side_effect = [None, Exception("Table doesn't exist"), None]
         
         df = pd.DataFrame({'col1': [1, 2], 'col2': ['a', 'b']})
         
@@ -230,8 +230,8 @@ class TestSaveDfDuckdb:
         
         # Assertions
         assert mock_query.call_count == 3
-        mock_query.assert_any_call(connection=mock_conn, query="INSERT INTO my_schema.test_table SELECT * FROM df")
         mock_query.assert_any_call(connection=mock_conn, query="CREATE SCHEMA IF NOT EXISTS my_schema")
+        mock_query.assert_any_call(connection=mock_conn, query="INSERT INTO my_schema.test_table SELECT * FROM df")
         mock_query.assert_any_call(connection=mock_conn, query="CREATE TABLE my_schema.test_table AS SELECT * FROM df")
 
 

--- a/tests/test_duckdb.py
+++ b/tests/test_duckdb.py
@@ -89,7 +89,8 @@ class TestReadSqlDuckdb:
     def test_read_sql_duckdb_motherduck_no_token_fallback(self, mock_makedirs, mock_query, mock_connect, mock_logger):
         """Test read_sql_duckdb with MotherDuck but no token, should fallback to local."""
         # Setup
-        mock_logger.return_value = MagicMock()
+        mock_logger_instance = MagicMock()
+        mock_logger.return_value = mock_logger_instance
         mock_conn = MagicMock()
         mock_connect.return_value = mock_conn
         expected_df = pd.DataFrame({'result': [42]})
@@ -100,7 +101,7 @@ class TestReadSqlDuckdb:
             result = read_sql_duckdb("SELECT 42 as result")
             
             # Assertions
-            mock_logger.return_value.warning.assert_called_once()
+            mock_logger_instance.warning.assert_called_once()
             mock_connect.assert_called_once_with("tmpdata/anomstack-duckdb.db")
             pd.testing.assert_frame_equal(result, expected_df)
     


### PR DESCRIPTION
This pull request includes changes to improve the configuration in the `.replit` file and updates to test cases in `tests/test_duckdb.py` to refine behavior and assertions for DuckDB operations. The most important changes are outlined below.

### Configuration updates:
* [`.replit`](diffhunk://#diff-dabe747bc6b60b9f68c11dfbf2fbc44d3d37bd289e8f7fdc88647cd697d5cbaeL7-R14): Reordered and re-added the port configuration for `localPort` 8080 and `externalPort` 80 to ensure proper port mapping.

### Test case improvements:
* [`tests/test_duckdb.py`](diffhunk://#diff-f7e20335f94b2719787a368acdb59f21fd6ebdc2f8c890d1ccf7de982ef925b8L92-R107): Updated `test_read_sql_duckdb_motherduck_no_token_fallback` to use a dedicated `mock_logger_instance` for clearer mocking and adjusted the environment variable patching to avoid clearing unrelated variables.
* [`tests/test_duckdb.py`](diffhunk://#diff-f7e20335f94b2719787a368acdb59f21fd6ebdc2f8c890d1ccf7de982ef925b8L219-R224): Modified `test_save_df_duckdb_with_schema` to ensure the sequence of operations reflects the correct order: `CREATE SCHEMA`, `INSERT`, and `CREATE TABLE`.
* [`tests/test_duckdb.py`](diffhunk://#diff-f7e20335f94b2719787a368acdb59f21fd6ebdc2f8c890d1ccf7de982ef925b8L229-R234): Adjusted assertions in `test_save_df_duckdb_with_schema` to verify the correct query calls for `CREATE SCHEMA`, `INSERT`, and `CREATE TABLE`.