### PR TITLE
Restructure job flows in alert processing

### DIFF
--- a/anomstack/jobs/alert.py
+++ b/anomstack/jobs/alert.py
@@ -174,7 +174,10 @@ def build_alert_job(spec: dict) -> JobDefinition:
 
             return df_alerts
 
-        save_alerts(alert(get_alerts()))
+        # Restructured job flow: both alert and save_alerts depend on get_alerts
+        df_alerts = get_alerts()
+        alert(df_alerts)
+        save_alerts(df_alerts)
 
     return _job
 

--- a/anomstack/jobs/change.py
+++ b/anomstack/jobs/change.py
@@ -214,7 +214,11 @@ def build_change_job(spec: dict) -> JobDefinition:
 
             return df_change_alerts
 
-        save_alerts(alert(detect_changes(get_change_data())))
+        # Restructured job flow: both alert and save_alerts depend on detect_changes output
+        df_data = get_change_data()
+        df_change_alerts = detect_changes(df_data)
+        alert(df_change_alerts)
+        save_alerts(df_change_alerts)
 
     return _job
 

--- a/anomstack/jobs/llmalert.py
+++ b/anomstack/jobs/llmalert.py
@@ -283,7 +283,10 @@ def build_llmalert_job(spec: dict) -> JobDefinition:
 
             return df_alerts
 
-        save_llmalerts(llmalert(get_llmalert_data()))
+        # Restructured job flow: save_llmalerts depends on llmalert output
+        df_data = get_llmalert_data()
+        df_alerts = llmalert(df_data)
+        save_llmalerts(df_alerts)
 
     return _job
 

--- a/tests/test_slack.py
+++ b/tests/test_slack.py
@@ -168,7 +168,7 @@ class TestSendAlertSlack:
     
     @patch.dict(os.environ, {
         'ANOMSTACK_SLACK_BOT_TOKEN': 'xoxb-test-token'
-    })
+    }, clear=True)
     def test_send_alert_slack_missing_channel(self):
         """Test Slack alert fails when channel is not specified."""
         with pytest.raises(ValueError, match="Slack channel not specified"):


### PR DESCRIPTION
- Updated `alert.py`, `change.py`, and `llmalert.py` to ensure that the `alert` and `save_alerts` functions depend on their respective data retrieval outputs, improving clarity and maintainability of the job definitions.
- Adjusted the test for Slack alerts to use `clear=True` for environment variable handling, enhancing test isolation.