### PR TITLE
Fix generate_insert_sql batching

### DIFF
--- a/anomstack/df/utils.py
+++ b/anomstack/df/utils.py
@@ -19,8 +19,8 @@ def log_df_info(df: pd.DataFrame, logger=None):
     logger.info("df.info():\n%s", info_str)
 
 
-def generate_insert_sql(df, table_name, batch_size=100) -> str:
-    """Generate SQL DDL and batched DML from DataFrame."""
+def generate_insert_sql(df, table_name, batch_size=100) -> list[str]:
+    """Generate batched INSERT statements from DataFrame."""
     columns = ', '.join(df.columns)
     insert_sqls = []
     for i in range(0, len(df), batch_size):
@@ -38,4 +38,4 @@ def generate_insert_sql(df, table_name, batch_size=100) -> str:
         insert_sql = f"INSERT INTO {table_name} ({columns}) VALUES {values};"
         insert_sqls.append(insert_sql)
 
-        return insert_sqls
+    return insert_sqls

--- a/tests/test_df_utils.py
+++ b/tests/test_df_utils.py
@@ -1,0 +1,37 @@
+import pandas as pd
+
+from anomstack.df.utils import generate_insert_sql
+
+
+class TestGenerateInsertSQL:
+    def test_batches_all_rows(self):
+        df = pd.DataFrame({"id": [1, 2, 3], "name": ["a", "b", "c"]})
+        result = generate_insert_sql(df, "my_table", batch_size=2)
+        expected = [
+            "INSERT INTO my_table (id, name) VALUES (1, 'a'), (2, 'b');",
+            "INSERT INTO my_table (id, name) VALUES (3, 'c');",
+        ]
+        assert result == expected
+
+    def test_timestamp_quoting(self):
+        df = pd.DataFrame(
+            {
+                "metric_timestamp": [
+                    pd.Timestamp("2023-01-01"),
+                    pd.Timestamp("2023-01-02"),
+                ],
+                "value": [10, 20],
+            }
+        )
+        result = generate_insert_sql(df, "metrics", batch_size=1)
+        expected = [
+            (
+                "INSERT INTO metrics (metric_timestamp, value) "
+                "VALUES ('2023-01-01 00:00:00', 10);"
+            ),
+            (
+                "INSERT INTO metrics (metric_timestamp, value) "
+                "VALUES ('2023-01-02 00:00:00', 20);"
+            ),
+        ]
+        assert result == expected


### PR DESCRIPTION
## Summary
- fix generate_insert_sql so that all batches are processed
- cover generate_insert_sql with new unit tests

## Testing
- `pre-commit run --files anomstack/df/utils.py tests/test_df_utils.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868402c5b708328a72f7a1076aa663e