### PR TITLE
Add insert SQL batching test and fix

### DIFF
--- a/anomstack/df/utils.py
+++ b/anomstack/df/utils.py
@@ -24,7 +24,7 @@ def generate_insert_sql(df, table_name, batch_size=100) -> str:
     columns = ', '.join(df.columns)
     insert_sqls = []
     for i in range(0, len(df), batch_size):
-        batch = df.iloc[i:i+batch_size]
+        batch = df.iloc[i:i + batch_size]
         values_list = []
         for _, row in batch.iterrows():
             row_values = []
@@ -38,4 +38,4 @@ def generate_insert_sql(df, table_name, batch_size=100) -> str:
         insert_sql = f"INSERT INTO {table_name} ({columns}) VALUES {values};"
         insert_sqls.append(insert_sql)
 
-        return insert_sqls
+    return insert_sqls

--- a/tests/test_sql_utils.py
+++ b/tests/test_sql_utils.py
@@ -1,0 +1,40 @@
+import pandas as pd
+from anomstack.df.utils import generate_insert_sql
+
+
+class TestGenerateInsertSql:
+    """Tests for the generate_insert_sql utility."""
+
+    def test_batches_and_values(self):
+        # Create DataFrame with more rows than default batch size (100)
+        df = pd.DataFrame({
+            "id": range(1, 251),
+            "value": [f"value_{i}" for i in range(1, 251)],
+        })
+
+        insert_sqls = generate_insert_sql(df, "test_table")
+
+        # Expect ceil(250/100) = 3 batches
+        assert len(insert_sqls) == 3
+
+        # Build expected SQL strings manually
+        columns = ", ".join(df.columns)
+        expected_sqls = []
+        for i in range(0, len(df), 100):
+            batch = df.iloc[i:i + 100]
+            values_list = []
+            for _, row in batch.iterrows():
+                row_values = []
+                for val in row:
+                    if isinstance(val, str) or isinstance(val, pd.Timestamp):
+                        row_values.append(f"'{val}'")
+                    else:
+                        row_values.append(str(val))
+                values_list.append(f"({', '.join(row_values)})")
+            values = ", ".join(values_list)
+            expected_sqls.append(
+                f"INSERT INTO test_table ({columns}) VALUES {values};"
+            )
+
+        assert insert_sqls == expected_sqls
+


### PR DESCRIPTION
## Summary
- fix `generate_insert_sql` to return all batches
- add tests covering SQL batching

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868405bea8883288103ccbafece7f74