### PR TITLE
Add script to run PostHog example

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ SHELL=/bin/bash
 .PHONY: dashboard-uvicorn
 .PHONY: dashboardd-uvicorn
 .PHONY: requirements-install
+.PHONY: posthog-example
 
 # start dagster locally
 local:
@@ -71,4 +72,8 @@ dashboardd-uvicorn:
 	nohup uvicorn dashboard.app:app --host 0.0.0.0 --port 5003 --reload > /dev/null 2>&1 &
 
 requirements-install:
-	pip install -r requirements.txt
+        pip install -r requirements.txt
+
+# run the PostHog example ingest function
+posthog-example:
+	python scripts/posthog_example.py

--- a/metrics/examples/README.md
+++ b/metrics/examples/README.md
@@ -29,6 +29,7 @@ A **metric batch** is Anomstack's core concept - a collection of related metrics
 - **[netdata_httpcheck](netdata_httpcheck/)**: Website availability monitoring
 - **[tomtom](tomtom/)**: TomTom traffic API integration
 - **[github](github/)**: GitHub API metrics (stars, issues, etc.)
+- **[posthog](posthog/)**: PostHog query API usage metrics
 - **[currency](currency/)**: Currency exchange rate monitoring
 - **[eirgrid](eirgrid/)**: Irish electrical grid data
 
@@ -112,4 +113,3 @@ See [`.example.env`](../../.example.env) for a complete list of available enviro
 - [weather](weather/): Example of a metric batch that uses Open Meteo data.
 - [weather_forecast](weather_forecast/): Example of a metric batch that uses weather forecast data from Snowflake.
 - [yfinance](yfinance/): Example of a metric batch that uses the Yahoo Finance API.
-

--- a/metrics/examples/posthog/README.md
+++ b/metrics/examples/posthog/README.md
@@ -1,0 +1,7 @@
+# PostHog
+
+Example using the [PostHog](https://posthog.com/) query API to pull headline metrics for **yesterday**.
+
+Set `POSTHOG_API_KEY` and `POSTHOG_PROJECT_ID` in your environment to authenticate. Optionally override `POSTHOG_HOST` for self-hosted instances.
+
+Run `make posthog-example` to execute the ingest script locally and verify your configuration.

--- a/metrics/examples/posthog/posthog.py
+++ b/metrics/examples/posthog/posthog.py
@@ -1,0 +1,88 @@
+import os
+
+import pandas as pd
+
+
+def ingest() -> pd.DataFrame:
+    """Ingest headline metrics from the PostHog query API."""
+    import requests
+    from dagster import get_dagster_logger
+
+    logger = get_dagster_logger()
+
+    api_key = os.getenv("POSTHOG_API_KEY")
+    project_id = os.getenv("POSTHOG_PROJECT_ID")
+    if not api_key or not project_id:
+        raise RuntimeError(
+            "POSTHOG_API_KEY and POSTHOG_PROJECT_ID env vars must be set"
+        )
+
+    host = os.getenv("POSTHOG_HOST", "https://app.posthog.com")
+    url = f"{host}/api/projects/{project_id}/query"
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+    }
+
+    query = """
+        SELECT
+            count() AS events_yesterday,
+            count(DISTINCT person_id) AS users_yesterday
+        FROM events
+        WHERE timestamp >= toStartOfDay(now() - INTERVAL 1 day)
+          AND timestamp < toStartOfDay(now())
+    """
+
+    try:
+        response = requests.post(
+            url, headers=headers, json={"query": query}, timeout=10
+        )
+        response.raise_for_status()
+    except requests.RequestException as ex:
+        logger.error(f"Failed to fetch PostHog data from {url}: {ex}")
+        return pd.DataFrame(columns=["metric_timestamp", "metric_name", "metric_value"])
+
+    data = response.json()
+
+    rows = []
+    ts = pd.Timestamp.utcnow().floor("s")
+    results = data.get("results") or data.get("data")
+    if results:
+        first = results[0]
+        if isinstance(first, dict):
+            events = first.get("events_yesterday")
+            users = first.get("users_yesterday")
+        elif isinstance(first, list):
+            columns = data.get("columns", [])
+            try:
+                events = first[columns.index("events_yesterday")]
+            except (ValueError, IndexError):
+                events = first[0]
+            try:
+                users = first[columns.index("users_yesterday")]
+            except (ValueError, IndexError):
+                users = first[1] if len(first) > 1 else None
+        else:
+            events = users = None
+
+        if events is not None:
+            rows.append(
+                {
+                    "metric_timestamp": ts,
+                    "metric_name": "posthog.events_yesterday",
+                    "metric_value": float(events),
+                }
+            )
+        if users is not None:
+            rows.append(
+                {
+                    "metric_timestamp": ts,
+                    "metric_name": "posthog.users_yesterday",
+                    "metric_value": float(users),
+                }
+            )
+
+    df = pd.DataFrame(rows)
+    df = df.dropna()
+    df = df[["metric_timestamp", "metric_name", "metric_value"]]
+    return df

--- a/metrics/examples/posthog/posthog.yaml
+++ b/metrics/examples/posthog/posthog.yaml
@@ -1,0 +1,13 @@
+metric_batch: "posthog"
+table_key: "metrics_posthog"
+ingest_cron_schedule: "15 5 * * *"
+train_cron_schedule: "45 5 * * *"
+score_cron_schedule: "15 5 * * *"
+alert_cron_schedule: "30 5 * * *"
+change_cron_schedule: "15 5 * * *"
+llmalert_cron_schedule: "45 5 * * *"
+plot_cron_schedule: "15 6 * * *"
+alert_always: False
+alert_methods: "email"
+ingest_fn: >
+  {% include "./examples/posthog/posthog.py" %}

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -11,6 +11,9 @@ The scripts in this directory provide helpful utilities for common administrativ
 ### `sqlite/`
 Contains SQLite-specific utility scripts for users running Anomstack with SQLite as their database backend.
 
+### `posthog_example.py`
+Runs the PostHog metrics ingest function to ensure your PostHog credentials work.
+
 ## Common Use Cases
 
 These scripts are typically used for:
@@ -57,4 +60,4 @@ When adding new utility scripts:
 - Include proper error handling and rollback mechanisms
 - Document any prerequisites or dependencies
 - Use appropriate logging levels for different operations
-- Follow the project's coding standards and conventions 
+- Follow the project's coding standards and conventions

--- a/scripts/posthog_example.py
+++ b/scripts/posthog_example.py
@@ -1,0 +1,14 @@
+from dotenv import load_dotenv
+
+from metrics.examples.posthog.posthog import ingest
+
+
+def main():
+    """Run the PostHog example ingest function and print results."""
+    load_dotenv(override=True)
+    df = ingest()
+    print(df)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,5 +1,3 @@
-import os
-from pathlib import Path
 import logging
 
 import pytest
@@ -11,7 +9,7 @@ logger = logging.getLogger(__name__)
 
 
 def test_jobs_len():
-    assert len(jobs) == 177
+    assert len(jobs) == 185
 
 
 def test_jobs_len_ingest():
@@ -19,7 +17,7 @@ def test_jobs_len_ingest():
 
 
 def test_schedules_len():
-    assert len(schedules) == 177
+    assert len(schedules) == 185
 
 
 def test_schedules_len_ingest():


### PR DESCRIPTION
## Summary
- provide a helper script to run the PostHog ingest function
- expose a `posthog-example` target in the Makefile
- document how to execute the PostHog example
- list the new script in `scripts/README.md`

## Testing
- `pre-commit run --files scripts/posthog_example.py Makefile metrics/examples/posthog/README.md scripts/README.md`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68683ea44da48328b17ba351533667ea