### PR TITLE
Fix posthog

### DIFF
--- a/metrics/examples/posthog/posthog.py
+++ b/metrics/examples/posthog/posthog.py
@@ -4,85 +4,75 @@ import pandas as pd
 
 
 def ingest() -> pd.DataFrame:
-    """Ingest headline metrics from the PostHog query API."""
+    """Ingest headline metrics from the PostHog query API for multiple projects/domains."""
     import requests
     from dagster import get_dagster_logger
 
     logger = get_dagster_logger()
-
     api_key = os.getenv("POSTHOG_API_KEY")
-    project_id = os.getenv("POSTHOG_PROJECT_ID")
-    if not api_key or not project_id:
-        raise RuntimeError(
-            "POSTHOG_API_KEY and POSTHOG_PROJECT_ID env vars must be set"
-        )
+    if not api_key:
+        raise RuntimeError("POSTHOG_API_KEY env var must be set")
+
+    project_domain_map = {
+        "1016": "andrewm4894.com",
+        "140227": "anomstack-demo",
+        "112495": "andys-daily-factoids.com",
+        "148051": "andys-daily-riddle.com",
+    }
 
     host = os.getenv("POSTHOG_HOST", "https://us.posthog.com")
-    url = f"{host}/api/projects/{project_id}/query"
-    headers = {
-        "Authorization": f"Bearer {api_key}",
-        "Content-Type": "application/json",
-    }
+    headers = {"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"}
 
     query = """
         SELECT
-            count() AS events_yesterday,
-            count(DISTINCT person_id) AS users_yesterday
+            count() AS events_yday,
+            count(DISTINCT person_id) AS users_yday,
+            countIf(event = '$pageview') AS pageviews_yday
         FROM events
         WHERE timestamp >= toStartOfDay(now() - INTERVAL 1 day)
           AND timestamp < toStartOfDay(now())
     """
 
-    try:
-        response = requests.post(
-            url, headers=headers, json={"query": {"kind": "HogQLQuery", "query": query}}, timeout=10
-        )
-        response.raise_for_status()
-    except requests.RequestException as ex:
-        logger.error(f"Failed to fetch PostHog data from {url}: {ex}")
-        return pd.DataFrame(columns=["metric_timestamp", "metric_name", "metric_value"])
-
-    data = response.json()
-
-    rows = []
+    all_rows = []
     ts = pd.Timestamp.utcnow().floor("s")
-    results = data.get("results") or data.get("data")
-    if results:
+    
+    for project_id, domain in project_domain_map.items():
+        url = f"{host}/api/projects/{project_id}/query"
+        try:
+            response = requests.post(url, headers=headers, json={"query": {"kind": "HogQLQuery", "query": query}}, timeout=10)
+            response.raise_for_status()
+        except requests.RequestException as ex:
+            logger.error(f"Failed to fetch PostHog data from {url}: {ex}")
+            continue
+
+        data = response.json()
+        results = data.get("results") or data.get("data")
+        if not results:
+            continue
+
         first = results[0]
         if isinstance(first, dict):
-            events = first.get("events_yesterday")
-            users = first.get("users_yesterday")
-        elif isinstance(first, list):
-            columns = data.get("columns", [])
-            try:
-                events = first[columns.index("events_yesterday")]
-            except (ValueError, IndexError):
-                events = first[0]
-            try:
-                users = first[columns.index("users_yesterday")]
-            except (ValueError, IndexError):
-                users = first[1] if len(first) > 1 else None
+            metrics = {
+                "events_yday": first.get("events_yday"),
+                "users_yday": first.get("users_yday"), 
+                "pageviews_yday": first.get("pageviews_yday")
+            }
         else:
-            events = users = None
+            # Handle list response
+            metrics = {
+                "events_yday": first[0] if len(first) > 0 else None,
+                "users_yday": first[1] if len(first) > 1 else None,
+                "pageviews_yday": first[2] if len(first) > 2 else None
+            }
 
-        if events is not None:
-            rows.append(
-                {
+        for metric_key, value in metrics.items():
+            if value is not None:
+                all_rows.append({
                     "metric_timestamp": ts,
-                    "metric_name": "posthog.events_yesterday",
-                    "metric_value": float(events),
-                }
-            )
-        if users is not None:
-            rows.append(
-                {
-                    "metric_timestamp": ts,
-                    "metric_name": "posthog.users_yesterday",
-                    "metric_value": float(users),
-                }
-            )
+                    "domain": domain,
+                    "metric_name": f"ph.{domain}.{metric_key}",
+                    "metric_value": float(value)
+                })
 
-    df = pd.DataFrame(rows)
-    df = df.dropna()
-    df = df[["metric_timestamp", "metric_name", "metric_value"]]
-    return df
+    df = pd.DataFrame(all_rows)
+    return df[["metric_timestamp", "domain", "metric_name", "metric_value"]] if not df.empty else df

--- a/metrics/examples/posthog/posthog.py
+++ b/metrics/examples/posthog/posthog.py
@@ -17,7 +17,7 @@ def ingest() -> pd.DataFrame:
             "POSTHOG_API_KEY and POSTHOG_PROJECT_ID env vars must be set"
         )
 
-    host = os.getenv("POSTHOG_HOST", "https://app.posthog.com")
+    host = os.getenv("POSTHOG_HOST", "https://us.posthog.com")
     url = f"{host}/api/projects/{project_id}/query"
     headers = {
         "Authorization": f"Bearer {api_key}",
@@ -35,7 +35,7 @@ def ingest() -> pd.DataFrame:
 
     try:
         response = requests.post(
-            url, headers=headers, json={"query": query}, timeout=10
+            url, headers=headers, json={"query": {"kind": "HogQLQuery", "query": query}}, timeout=10
         )
         response.raise_for_status()
     except requests.RequestException as ex:

--- a/metrics/examples/posthog/posthog.yaml
+++ b/metrics/examples/posthog/posthog.yaml
@@ -6,8 +6,5 @@ score_cron_schedule: "15 5 * * *"
 alert_cron_schedule: "30 5 * * *"
 change_cron_schedule: "15 5 * * *"
 llmalert_cron_schedule: "45 5 * * *"
-plot_cron_schedule: "15 6 * * *"
-alert_always: False
-alert_methods: "email"
 ingest_fn: >
   {% include "./examples/posthog/posthog.py" %}

--- a/scripts/posthog_example.py
+++ b/scripts/posthog_example.py
@@ -1,4 +1,5 @@
 from dotenv import load_dotenv
+import pandas as pd
 
 from metrics.examples.posthog.posthog import ingest
 
@@ -6,6 +7,7 @@ from metrics.examples.posthog.posthog import ingest
 def main():
     """Run the PostHog example ingest function and print results."""
     load_dotenv(override=True)
+    pd.set_option("display.max_columns", None)
     df = ingest()
     print(df)
 


### PR DESCRIPTION
This pull request introduces enhancements to the PostHog metrics ingestion logic, updates the associated cron schedules, and improves the usability of the example script. The most significant changes include support for ingesting metrics from multiple projects/domains, additional metrics for pageviews, and adjustments to the script for better output readability.

### Enhancements to PostHog ingestion logic:
* [`metrics/examples/posthog/posthog.py`](diffhunk://#diff-7d54e606b1ef0ef3a9dde0e3088fd5e6ee693cbc5d5074a2f3c067b0d24ca4bfL7-R78): Updated the `ingest` function to support fetching metrics from multiple projects/domains using a `project_domain_map`. Added a new metric for pageviews (`pageviews_yday`) and improved handling of response data. The output now includes a `domain` column for clarity.

### Updates to cron schedules:
* [`metrics/examples/posthog/posthog.yaml`](diffhunk://#diff-473974a67d63e2683177122d98ba42296e5f7e3284332bdafe820ac1d82c4084L9-L11): Removed unused `plot_cron_schedule` and alert-related configurations (`alert_always` and `alert_methods`).

### Improvements to example script:
* [`scripts/posthog_example.py`](diffhunk://#diff-e6fa9b14605eb0782b0cbf164102716903c2926509d6fb8f049a86ab05e122d9R2-R10): Added `pandas` import and set the display option for maximum columns to ensure all columns are visible when printing the DataFrame.