### PR TITLE
Add timeout sensor for long Dagster runs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ SHELL=/bin/bash
 .PHONY: dashboardd-uvicorn
 .PHONY: requirements-install
 .PHONY: posthog-example
+.PHONY: kill-zombies
 
 # start dagster locally
 local:
@@ -82,3 +83,7 @@ requirements-install:
 # run the PostHog example ingest function
 posthog-example:
 	python scripts/posthog_example.py
+
+# cancel long running Dagster runs
+kill-zombies:
+	python scripts/kill_zombie_runs.py

--- a/anomstack/main.py
+++ b/anomstack/main.py
@@ -14,6 +14,7 @@ from anomstack.jobs.score import score_jobs, score_schedules
 from anomstack.jobs.summary import summary_jobs, summary_schedules
 from anomstack.jobs.train import train_jobs, train_schedules
 from anomstack.sensors.failure import email_on_run_failure
+from anomstack.sensors.timeout import kill_long_running_runs
 
 jobs = (
     ingest_jobs
@@ -26,7 +27,7 @@ jobs = (
     + summary_jobs
     + delete_jobs
 )
-sensors = [email_on_run_failure]
+sensors = [email_on_run_failure, kill_long_running_runs]
 schedules = (
     ingest_schedules
     + train_schedules

--- a/anomstack/sensors/timeout.py
+++ b/anomstack/sensors/timeout.py
@@ -1,0 +1,53 @@
+"""Sensor to cancel long running Dagster runs."""
+
+from __future__ import annotations
+
+import os
+import time
+from typing import Optional
+
+from dagster import (
+    DagsterInstance,
+    DagsterRunStatus,
+    RunsFilter,
+    SensorEvaluationContext,
+    sensor,
+)
+
+MAX_RUNTIME_SECONDS = int(os.getenv("ANOMSTACK_RUN_TIMEOUT_SECONDS", "3600"))
+CHECK_INTERVAL_SECONDS = int(os.getenv("ANOMSTACK_RUN_TIMEOUT_INTERVAL", "60"))
+
+
+def terminate_long_running_runs(
+    instance: Optional[DagsterInstance] = None,
+    *,
+    max_runtime: int = MAX_RUNTIME_SECONDS,
+    log=None,
+) -> None:
+    """Cancel any runs executing longer than ``max_runtime`` seconds."""
+    instance = instance or DagsterInstance.get()
+    now = time.time()
+    records = instance.get_run_records(
+        RunsFilter(statuses=[DagsterRunStatus.STARTED, DagsterRunStatus.STARTING])
+    )
+    for record in records:
+        if record.start_time and now - record.start_time > max_runtime:
+            run_id = record.dagster_run.run_id
+            if log:
+                log.info(f"Canceling long running run {run_id}")
+            if instance.run_coordinator:
+                try:
+                    instance.run_coordinator.cancel_run(run_id)
+                except Exception as exc:  # pragma: no cover - best effort
+                    if log:
+                        log.warning(f"Failed to cancel run {run_id}: {exc}")
+            else:
+                instance.report_run_canceling(record.dagster_run)
+                instance.run_launcher.terminate(run_id)
+                instance.report_run_canceled(record.dagster_run)
+
+
+@sensor(name="kill_long_running_runs", minimum_interval_seconds=CHECK_INTERVAL_SECONDS)
+def kill_long_running_runs(context: SensorEvaluationContext):
+    """Dagster sensor to cancel runs exceeding ``MAX_RUNTIME_SECONDS``."""
+    terminate_long_running_runs(context.instance, log=context.log)

--- a/scripts/kill_zombie_runs.py
+++ b/scripts/kill_zombie_runs.py
@@ -1,0 +1,6 @@
+"""Utility script to cancel long running Dagster runs."""
+
+from anomstack.sensors.timeout import terminate_long_running_runs
+
+if __name__ == "__main__":
+    terminate_long_running_runs()


### PR DESCRIPTION
## Summary
- stop zombie Dagster runs with new `kill_long_running_runs` sensor
- provide helper script `kill_zombie_runs.py`
- expose a `kill-zombies` command in the Makefile
- register the sensor in `anomstack.main`

## Testing
- `ruff check .` *(fails: Found 70 errors)*
- `make tests`

------
https://chatgpt.com/codex/tasks/task_e_686998dd6f288328a9c67758380e26bf