### PR TITLE
Add sensor to kill long Dagster runs

### DIFF
--- a/.example.env
+++ b/.example.env
@@ -100,6 +100,8 @@ DAGSTER_HOME=/opt/dagster/dagster_home
 # max runtime for a job in dagster
 # https://docs.dagster.io/deployment/run-monitoring#general-run-timeouts
 ANOMSTACK_MAX_RUNTIME_SECONDS_TAG=3600
+# kill runs that exceed this many minutes
+ANOMSTACK_KILL_RUN_AFTER_MINUTES=60
 
 # postgres related env vars
 ANOMSTACK_POSTGRES_USER=postgres_user

--- a/Makefile
+++ b/Makefile
@@ -213,8 +213,12 @@ requirements-install:
 # UTILITIES
 # =============================================================================
 
-.PHONY: posthog-example
+.PHONY: posthog-example kill-long-runs
 
 # run the PostHog example ingest function
 posthog-example:
-	python scripts/posthog_example.py
+        python scripts/posthog_example.py
+
+# kill any dagster runs exceeding configured timeout
+kill-long-runs:
+        python scripts/kill_long_running_tasks.py

--- a/README.md
+++ b/README.md
@@ -620,6 +620,18 @@ Below you see an example of an LLM alert via email. In this case we add a descri
 
 </details>
 
+## Killing Long Running Jobs
+
+Sometimes Dagster runs can get stuck. Anomstack ships with a sensor that
+terminates any run exceeding a configurable timeout. By default runs are killed
+after 60 minutes. You can override this in your `dagster.yaml` or via the
+`ANOMSTACK_KILL_RUN_AFTER_MINUTES` environment variable. You can also invoke the
+cleanup manually with:
+
+```bash
+make kill-long-runs
+```
+
 ## Contributing
 
 Read the [contributing guide](./CONTRIBUTING.md) to learn about our development process, how to propose bugfixes and improvements, and how to build and test your changes to Anomstack.

--- a/anomstack/main.py
+++ b/anomstack/main.py
@@ -14,6 +14,7 @@ from anomstack.jobs.score import score_jobs, score_schedules
 from anomstack.jobs.summary import summary_jobs, summary_schedules
 from anomstack.jobs.train import train_jobs, train_schedules
 from anomstack.sensors.failure import email_on_run_failure
+from anomstack.sensors.timeout import kill_long_running_runs
 
 jobs = (
     ingest_jobs
@@ -26,7 +27,7 @@ jobs = (
     + summary_jobs
     + delete_jobs
 )
-sensors = [email_on_run_failure]
+sensors = [email_on_run_failure, kill_long_running_runs]
 schedules = (
     ingest_schedules
     + train_schedules

--- a/anomstack/sensors/timeout.py
+++ b/anomstack/sensors/timeout.py
@@ -1,0 +1,88 @@
+import os
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import yaml
+from dagster import (
+    DagsterRunStatus,
+    RunsFilter,
+    SensorEvaluationContext,
+    SkipReason,
+    sensor,
+)
+from dagster._core.errors import DagsterUserCodeUnreachableError
+
+DEFAULT_MINUTES = 60
+
+def _load_config_timeout_minutes() -> int:
+    env_val = os.getenv("ANOMSTACK_KILL_RUN_AFTER_MINUTES")
+    if env_val:
+        try:
+            return int(env_val)
+        except ValueError:
+            pass
+
+    dagster_home = Path(os.getenv("DAGSTER_HOME", ""))
+    if not dagster_home:
+        dagster_home = Path.cwd()
+    config_path = dagster_home / "dagster.yaml"
+    minutes = DEFAULT_MINUTES
+    if config_path.exists():
+        try:
+            with open(config_path, "r", encoding="utf-8") as f:
+                cfg = yaml.safe_load(f)
+            minutes = int(cfg.get("kill_sensor", {}).get("kill_after_minutes", minutes))
+        except Exception:
+            pass
+    return minutes
+
+
+def get_kill_after_minutes() -> int:
+    """Return minutes after which to kill a running task."""
+    return _load_config_timeout_minutes()
+
+
+@sensor(minimum_interval_seconds=60)
+def kill_long_running_runs(context: SensorEvaluationContext):
+    """Terminate Dagster runs that exceed a configured runtime."""
+    kill_after = get_kill_after_minutes()
+    instance = context.instance
+    cutoff = datetime.now(timezone.utc) - timedelta(minutes=kill_after)
+    running_runs = instance.get_runs(
+        filters=RunsFilter(statuses=[DagsterRunStatus.STARTED])
+    )
+    killed = 0
+    for run in running_runs:
+        run_stats = instance.get_run_stats(run.run_id)
+        if run_stats.start_time is None:
+            continue
+        started_at = datetime.fromtimestamp(run_stats.start_time, tz=timezone.utc)
+        duration = datetime.now(timezone.utc) - started_at
+        if started_at < cutoff:
+            try:
+                context.log.info(
+                    f"Terminating run {run.run_id} running for {duration}"
+                )
+                instance.report_run_canceling(run)
+                instance.run_launcher.terminate(run.run_id)
+                killed += 1
+            except DagsterUserCodeUnreachableError as exc:
+                context.log.warning(
+                    (
+                        f"Could not terminate run {run.run_id}: {exc}. "
+                        "Marking as failed."
+                    )
+                )
+                instance.report_run_failed(run)
+            except Exception as exc:
+                context.log.error(
+                    (
+                        f"Unexpected error terminating run {run.run_id}: {exc}. "
+                        "Marking as failed."
+                    )
+                )
+                instance.report_run_failed(run)
+    if killed == 0:
+        yield SkipReason("No long running runs found")
+    else:
+        yield SkipReason(f"Killed {killed} long running run(s)")

--- a/dagster.yaml
+++ b/dagster.yaml
@@ -44,3 +44,7 @@ retention:
 
 telemetry:
   enabled: true
+
+# kill sensor configuration
+kill_sensor:
+  kill_after_minutes: 60

--- a/dagster_docker.yaml
+++ b/dagster_docker.yaml
@@ -60,6 +60,10 @@ run_monitoring:
   start_timeout_seconds: 600
   cancel_timeout_seconds: 300
 
+# kill sensor configuration
+kill_sensor:
+  kill_after_minutes: 60
+
 schedule_storage:
   module: dagster_postgres.schedule_storage
   class: PostgresScheduleStorage

--- a/tests/test_timeout_sensor.py
+++ b/tests/test_timeout_sensor.py
@@ -1,0 +1,22 @@
+
+from anomstack.sensors.timeout import get_kill_after_minutes
+
+
+def test_get_kill_after_minutes_env(monkeypatch):
+    monkeypatch.setenv("ANOMSTACK_KILL_RUN_AFTER_MINUTES", "30")
+    assert get_kill_after_minutes() == 30
+    monkeypatch.delenv("ANOMSTACK_KILL_RUN_AFTER_MINUTES")
+
+
+def test_get_kill_after_minutes_yaml(tmp_path, monkeypatch):
+    yaml_file = tmp_path / "dagster.yaml"
+    yaml_file.write_text("kill_sensor:\n  kill_after_minutes: 45\n")
+    monkeypatch.setenv("DAGSTER_HOME", str(tmp_path))
+    assert get_kill_after_minutes() == 45
+    monkeypatch.delenv("DAGSTER_HOME")
+
+
+def test_get_kill_after_minutes_default(tmp_path, monkeypatch):
+    monkeypatch.setenv("DAGSTER_HOME", str(tmp_path))
+    assert get_kill_after_minutes() == 60
+    monkeypatch.delenv("DAGSTER_HOME")


### PR DESCRIPTION
## Summary
- introduce `kill_long_running_runs` sensor to terminate hangs
- configure timeout in `dagster.yaml` and `.example.env`
- wire the sensor into `main.py`
- document and expose `make kill-long-runs` helper
- add unit tests for timeout config

## Testing
- `pre-commit run --files anomstack/sensors/timeout.py anomstack/main.py tests/test_timeout_sensor.py README.md Makefile .example.env dagster.yaml dagster_docker.yaml`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687814a58b948328b0f433274f5f14e8