### PR TITLE
Add dev codespace link

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,5 +1,7 @@
 # Devcontainer Configurations
 
+[![Open Dev Codespace](https://img.shields.io/badge/Codespace-Dev-blue?logo=github)](https://github.com/codespaces/new/andrewm4894/anomstack?devcontainer_path=.devcontainer/devcontainer.dev.json)
+
 This directory contains multiple devcontainer configurations for different use cases.
 
 ## 📋 Available Configurations
@@ -8,7 +10,7 @@ This directory contains multiple devcontainer configurations for different use c
 - **Purpose**: Quick start for new users or demos
 - **Docker Strategy**: Pulls pre-built images from Docker Hub
 - **Speed**: ⚡ Fast startup (30-60 seconds)
-- **Use Cases**: 
+- **Use Cases**:
   - New users trying out anomstack
   - Demos and presentations
   - Quick testing without development setup
@@ -27,12 +29,12 @@ This directory contains multiple devcontainer configurations for different use c
 ### GitHub Codespaces
 
 1. **Default (User/Demo)**: Just click "Create codespace" - uses `devcontainer.json`
-2. **Development**: When creating a codespace, click "..." → "Configure dev container" → select `devcontainer.dev.json`
+2. **Development**: Use the **Dev Codespace** link above or when creating a codespace click "..." → "Configure dev container" → select `devcontainer.dev.json`
 
 ### VS Code Dev Containers
 
 1. **Default**: Open folder in VS Code → "Reopen in Container"
-2. **Development**: 
+2. **Development**:
    - Open Command Palette (`Ctrl+Shift+P`)
    - "Dev Containers: Reopen in Container"
    - Select `devcontainer.dev.json`
@@ -78,4 +80,4 @@ Both configurations provide:
 
 ## 📚 Documentation
 
-For more information, see the main [README.md](../README.md) and [DOCKER.md](../DOCKER.md) files. 
+For more information, see the main [README.md](../README.md) and [DOCKER.md](../DOCKER.md) files.

--- a/Makefile
+++ b/Makefile
@@ -171,7 +171,17 @@ kill-dashboardd:
 # TESTING & QUALITY
 # =============================================================================
 
-.PHONY: tests coverage pre-commit
+.PHONY: tests coverage pre-commit fmt lint
+
+# run code formatters (black, isort, ruff)
+fmt:
+	black .
+	isort .
+	ruff --fix .
+
+# run ruff without modifying files
+lint:
+	ruff .
 
 # run pre-commit hooks on all files
 pre-commit:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Anomstack
 
 [![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/andrewm4894/anomstack)
+[![Open Dev Codespace](https://img.shields.io/badge/Codespace-Dev-blue?logo=github)](https://github.com/codespaces/new/andrewm4894/anomstack?devcontainer_path=.devcontainer/devcontainer.dev.json)
 
 [![Run on Repl.it](https://replit.com/badge/github/andrewm4894/anomstack)](https://replit.com/new/github/andrewm4894/anomstack)
 
@@ -442,6 +443,8 @@ There are some more detailed instructions (WIP) in [`/docs/deployment/`](./docs/
 [![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/andrewm4894/anomstack)
 
 You can run Anomstack using docker in a [GitHub Codespace](https://docs.github.com/en/codespaces). This is a great way to get started and familiar with Anomstack without having to install or run anything locally.
+
+If you want a full development environment that builds the Docker images from the local `Dockerfile`s, use the **Dev Codespace** link above or choose `devcontainer.dev.json` when configuring your codespace.
 
 You can see the [`.devcontainer`](./.devcontainer) folder for the config used to run Anomstack in a codespace and the post create script [`post_create_command.sh`](.devcontainer/post_create_command.sh) for the commands the devcontainer will run to get Anomstack up and running.
 


### PR DESCRIPTION
## Summary
- provide a badge to open a dev codespace that uses `devcontainer.dev.json`
- clarify how to use this configuration
- add `fmt` and `lint` helper targets in the Makefile

## Testing
- `pre-commit run --files README.md .devcontainer/README.md Makefile`
- `make tests`

------
https://chatgpt.com/codex/tasks/task_e_68781ba14398832899f4ecd94a70ad99