### PR TITLE
feat: add nginx configuration for dashboard static assets

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -66,6 +66,17 @@ http {
             proxy_buffering off;
         }
 
+        # Dashboard static assets (no authentication)
+        location ^~ /dashboard/static/ {
+            proxy_pass http://localhost:8080;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto https;
+            proxy_set_header X-Forwarded-Port 443;
+            proxy_buffering off;
+        }
+
         # Dagster homepage entry point
         location = /dagster {
             # Basic authentication for Dagster access


### PR DESCRIPTION
- Introduced a new location block for serving dashboard static assets without authentication.
- Configured proxy settings to ensure proper handling of requests to the dashboard.

This change enhances the accessibility of dashboard resources while maintaining existing security measures for other endpoints.

This pull request introduces a new location block in the `nginx.conf` file to serve static assets for the dashboard without requiring authentication.

* [`nginx.conf`](diffhunk://#diff-1f91f64bfa3fb0a1ece881887af0a2356b8c529a96fb91c1894745b2a1a009aaR69-R79): Added a `location` block for `/dashboard/static/` to proxy requests to `http://localhost:8080` with appropriate headers and disabled proxy buffering.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Requests to `/dashboard/static/` are now served without authentication, allowing direct access to dashboard static assets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->