### PR TITLE
Fix broken documentation links causing CI failure

### DIFF
--- a/docs/docs/data-sources.md
+++ b/docs/docs/data-sources.md
@@ -1,0 +1,47 @@
+---
+sidebar_position: 4
+---
+
+# Data Sources
+
+Anomstack supports multiple data sources for ingesting metrics. Choose the data source that matches your infrastructure:
+
+## Supported Data Sources
+
+### 🐍 Programming Languages
+- **[Python](data-sources/python)** - Direct Python functions for custom data ingestion
+
+### ☁️ Cloud Data Warehouses  
+- **[BigQuery](data-sources/bigquery)** - Google Cloud's serverless data warehouse
+- **[Snowflake](data-sources/snowflake)** - Cloud-native data platform
+- **[Redshift](data-sources/redshift)** - Amazon's data warehouse service
+
+### 🗄️ Databases
+- **[DuckDB](data-sources/duckdb)** - Embedded analytical database  
+- **[MotherDuck](data-sources/motherduck)** - Serverless DuckDB in the cloud
+- **[SQLite](data-sources/sqlite)** - Lightweight file-based database
+- **[ClickHouse](data-sources/clickhouse)** - Columnar database for analytics
+- **[Turso](data-sources/turso)** - SQLite for the edge
+
+## Getting Started
+
+1. **Choose your data source** from the list above
+2. **Follow the setup guide** for your specific data source
+3. **Configure connection details** in your environment variables
+4. **Create metric configurations** that query your data
+5. **Run your first anomaly detection job**
+
+## Universal Concepts
+
+All data sources work with the same core concepts:
+
+- **SQL queries** to extract time-series metrics
+- **Environment variables** for connection configuration  
+- **Metric batches** to organize related metrics
+- **Schedules** to run data ingestion automatically
+
+## Need Help?
+
+- Check the [environment variables guide](configuration/environment-variables) for connection setup
+- Review metric configuration examples in the [metrics directory](https://github.com/andrewm4894/anomstack/tree/main/metrics/examples) 
+- Join our [GitHub Discussions](https://github.com/andrewm4894/anomstack/discussions) for community support 

--- a/docs/docs/deployment/fly.md
+++ b/docs/docs/deployment/fly.md
@@ -621,12 +621,12 @@ After successful deployment:
 
 ## Related Resources
 
-- **📁 Quick Reference**: [fly.md](../../../fly.md) in repository root
+- **📁 Quick Reference**: [fly.md](https://github.com/andrewm4894/anomstack/blob/main/fly.md) in repository root
 - **🌐 Fly.io Docs**: [fly.io/docs](https://fly.io/docs)
 - **💬 Community**: [community.fly.io](https://community.fly.io)
 - **🐛 Issues**: [GitHub Issues](https://github.com/andrewm4894/anomstack/issues)
 - **📧 Alerts Setup**: [Email Configuration](../features/alerts.md)
-- **💬 Slack Setup**: [Slack Integration](../features/alerts.md#slack-alerts)
+- **💬 Slack Setup**: [Slack Integration](../features/alerts.md)
 
 :::info Questions?
 Join our [GitHub Discussions](https://github.com/andrewm4894/anomstack/discussions) or file an issue for deployment help!

--- a/docs/docs/quickstart.md
+++ b/docs/docs/quickstart.md
@@ -253,7 +253,7 @@ Now that you're up and running:
 1. **[Learn the core concepts](concepts)** - Understand metric batches, jobs, and the ML workflow
 2. **[Configure environment variables](configuration/environment-variables)** - Set up database connections, alerts, and advanced options
 3. **[Configure alerts](features/alerts)** - Get notified of anomalies via email/Slack  
-4. **[Explore data sources](data-sources/)** - Connect to BigQuery, Snowflake, ClickHouse, and more
+4. **[Explore data sources](data-sources/bigquery)** - Connect to BigQuery, Snowflake, ClickHouse, and more
 5. **[Deploy to production](deployment/)** - Use Dagster Cloud, scale with Docker, or deploy on your infrastructure
 
 ---

--- a/docs/docs/quickstart.md
+++ b/docs/docs/quickstart.md
@@ -253,7 +253,7 @@ Now that you're up and running:
 1. **[Learn the core concepts](concepts)** - Understand metric batches, jobs, and the ML workflow
 2. **[Configure environment variables](configuration/environment-variables)** - Set up database connections, alerts, and advanced options
 3. **[Configure alerts](features/alerts)** - Get notified of anomalies via email/Slack  
-4. **[Explore data sources](data-sources/)** - Connect to BigQuery, Snowflake, ClickHouse, and more
+4. **[Explore data sources](data-sources)** - Connect to BigQuery, Snowflake, ClickHouse, and more
 5. **[Deploy to production](deployment/)** - Use Dagster Cloud, scale with Docker, or deploy on your infrastructure
 
 ---

--- a/docs/docs/quickstart.md
+++ b/docs/docs/quickstart.md
@@ -253,7 +253,7 @@ Now that you're up and running:
 1. **[Learn the core concepts](concepts)** - Understand metric batches, jobs, and the ML workflow
 2. **[Configure environment variables](configuration/environment-variables)** - Set up database connections, alerts, and advanced options
 3. **[Configure alerts](features/alerts)** - Get notified of anomalies via email/Slack  
-4. **[Explore data sources](data-sources/bigquery)** - Connect to BigQuery, Snowflake, ClickHouse, and more
+4. **[Explore data sources](data-sources/)** - Connect to BigQuery, Snowflake, ClickHouse, and more
 5. **[Deploy to production](deployment/)** - Use Dagster Cloud, scale with Docker, or deploy on your infrastructure
 
 ---

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -41,6 +41,10 @@ const sidebars = {
     {
       type: 'category',
       label: 'Data Sources',
+      link: {
+        type: 'doc',
+        id: 'data-sources',
+      },
       items: [
         'data-sources/python',
         'data-sources/bigquery',


### PR DESCRIPTION
- Fix fly.md link to point to GitHub repository
- Fix data-sources link to point to specific page
- Remove broken slack-alerts anchor

This pull request includes minor documentation updates to improve the accuracy and consistency of links in the `fly.md` and `quickstart.md` files.

### Documentation updates:

* [`docs/docs/deployment/fly.md`](diffhunk://#diff-93d7fa2aa48fd058d731df8bd80014c2edc047976b7e42eaeceba1b99ab86f7fL624-R629): Updated the "Quick Reference" link to point to the correct GitHub URL for the `fly.md` file and adjusted the "Slack Setup" link for consistency.  
* [`docs/docs/quickstart.md`](diffhunk://#diff-db23839e9fa71374d53983730e318028367dff34e8c817cd1e8acfec09624fe8L256-R256): Updated the "Explore data sources" link to specifically reference the BigQuery page for improved clarity.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated resource links in the deployment documentation for improved accuracy and accessibility.
  * Added a new comprehensive guide detailing supported data sources, setup steps, and usage instructions.
  * Improved navigation by making the "Data Sources" sidebar category a clickable link.
  * Corrected a link in the quickstart guide for better consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->