### PR TITLE
Improve max runtime

### DIFF
--- a/.example.env
+++ b/.example.env
@@ -111,9 +111,9 @@ DAGSTER_CODE_SERVER_HOST=
 
 # max runtime for a job in dagster
 # https://docs.dagster.io/deployment/run-monitoring#general-run-timeouts
-ANOMSTACK_MAX_RUNTIME_SECONDS_TAG=3600
+ANOMSTACK_MAX_RUNTIME_SECONDS_TAG=900
 # kill runs that exceed this many minutes
-ANOMSTACK_KILL_RUN_AFTER_MINUTES=60
+ANOMSTACK_KILL_RUN_AFTER_MINUTES=15
 
 # postgres related env vars
 ANOMSTACK_POSTGRES_USER=postgres_user

--- a/README.md
+++ b/README.md
@@ -699,7 +699,7 @@ Below you see an example of an LLM alert via email. In this case we add a descri
 
 Sometimes Dagster runs can get stuck. Anomstack ships with a sensor that
 terminates any run exceeding a configurable timeout. By default runs are killed
-after 60 minutes. You can override this in your `dagster.yaml` or via the
+after 15 minutes. You can override this in your `dagster.yaml` or via the
 `ANOMSTACK_KILL_RUN_AFTER_MINUTES` environment variable. You can also invoke the
 cleanup manually with:
 

--- a/anomstack/sensors/timeout.py
+++ b/anomstack/sensors/timeout.py
@@ -12,7 +12,7 @@ from dagster import (
 )
 from dagster._core.errors import DagsterUserCodeUnreachableError
 
-DEFAULT_MINUTES = 60
+DEFAULT_MINUTES = 15
 
 def _load_config_timeout_minutes() -> int:
     env_val = os.getenv("ANOMSTACK_KILL_RUN_AFTER_MINUTES")

--- a/dagster.yaml
+++ b/dagster.yaml
@@ -11,7 +11,7 @@ run_monitoring:
   enabled: true
   start_timeout_seconds: 300   # 5 minutes to start
   cancel_timeout_seconds: 180  # 3 minutes to cancel
-  max_runtime_seconds: 3600    # 1 hour max runtime per run
+  max_runtime_seconds: 900     # 15 minutes max runtime per run
   poll_interval_seconds: 60    # Check every minute
 
 storage:

--- a/dagster_docker.yaml
+++ b/dagster_docker.yaml
@@ -72,7 +72,7 @@ run_monitoring:
   enabled: true
   start_timeout_seconds: 300   # 5 minutes to start
   cancel_timeout_seconds: 180  # 3 minutes to cancel
-  max_runtime_seconds: 3600    # 1 hour max runtime per run
+  max_runtime_seconds: 900     # 15 minutes max runtime per run
   max_resume_run_attempts: 2   # Resume runs after worker crashes (DockerRunLauncher only)
   poll_interval_seconds: 60    # Check every minute
 

--- a/dagster_fly.yaml
+++ b/dagster_fly.yaml
@@ -44,7 +44,7 @@ run_monitoring:
   enabled: true
   start_timeout_seconds: 300   # 5 minutes to start (increased for cold starts)
   cancel_timeout_seconds: 180  # 3 minutes to cancel (increased)
-  max_runtime_seconds: 3600    # 1 hour max runtime per run
+  max_runtime_seconds: 900     # 15 minutes max runtime per run
   poll_interval_seconds: 30    # Check every 30 seconds (more frequent)
 
 # Disable telemetry

--- a/docker/Dockerfile.anomstack_code
+++ b/docker/Dockerfile.anomstack_code
@@ -17,6 +17,9 @@ COPY anomstack /opt/dagster/app/anomstack
 
 COPY metrics /opt/dagster/app/metrics
 
+# Copy maintenance scripts for operational use
+COPY scripts/maintenance /opt/dagster/app/scripts/maintenance
+
 COPY .example.env .env
 
 # Run dagster gRPC server on port 4000

--- a/docker/Dockerfile.anomstack_dashboard
+++ b/docker/Dockerfile.anomstack_dashboard
@@ -26,6 +26,9 @@ COPY anomstack/sql /opt/dagster/app/anomstack/sql
 COPY anomstack/df /opt/dagster/app/anomstack/df
 COPY anomstack/validate /opt/dagster/app/anomstack/validate
 
+# Copy maintenance scripts for operational use
+COPY scripts/maintenance /opt/dagster/app/scripts/maintenance
+
 # Add current directory to Python path for anomstack imports
 ENV PYTHONPATH=/opt/dagster/app:$PYTHONPATH
 

--- a/docker/Dockerfile.dagster
+++ b/docker/Dockerfile.dagster
@@ -21,6 +21,9 @@ COPY dagster_docker.yaml $DAGSTER_HOME/dagster.yaml
 
 COPY workspace.yaml $DAGSTER_HOME
 
+# Copy maintenance scripts for operational use
+COPY scripts/maintenance /opt/dagster/scripts/maintenance
+
 COPY .example.env .env
 
 WORKDIR $DAGSTER_HOME

--- a/docs/docs/configuration/environment-variables.md
+++ b/docs/docs/configuration/environment-variables.md
@@ -181,8 +181,8 @@ Lightweight defaults to prevent disk space issues.
 
 | Variable | Required | Description | Default | Example |
 |----------|----------|-------------|---------|---------|
-| `ANOMSTACK_MAX_RUNTIME_SECONDS_TAG` | No | Max job runtime in seconds | `3600` | `7200` |
-| `ANOMSTACK_KILL_RUN_AFTER_MINUTES` | No | Kill long-running jobs after N minutes | `60` | `120` |
+| `ANOMSTACK_MAX_RUNTIME_SECONDS_TAG` | No | Max job runtime in seconds | `900` | `1800` |
+| `ANOMSTACK_KILL_RUN_AFTER_MINUTES` | No | Kill long-running jobs after N minutes | `15` | `30` |
 
 ## 🐳 Docker & Deployment
 

--- a/docs/docs/storage-optimization.md
+++ b/docs/docs/storage-optimization.md
@@ -60,7 +60,7 @@ run_monitoring:
   enabled: true
   start_timeout_seconds: 300
   cancel_timeout_seconds: 180
-  max_runtime_seconds: 3600
+  max_runtime_seconds: 900
   poll_interval_seconds: 60
 
 # Disabled telemetry to reduce disk writes

--- a/profiles/demo.env
+++ b/profiles/demo.env
@@ -17,7 +17,7 @@ ANOMSTACK_MODEL_PATH=local:///data/models
 
 # max runtime for a job in dagster
 # https://docs.dagster.io/deployment/run-monitoring#general-run-timeouts
-ANOMSTACK_MAX_RUNTIME_SECONDS_TAG=3600
+ANOMSTACK_MAX_RUNTIME_SECONDS_TAG=900
 
 # Enable Netdata
 ANOMSTACK__NETDATA__INGEST_DEFAULT_SCHEDULE_STATUS=RUNNING


### PR DESCRIPTION
This pull request reduces the maximum runtime for Dagster jobs from 60 minutes to 15 minutes across multiple configurations, documentation, and code files. It also introduces maintenance scripts into Docker images for operational use.

### Runtime Configuration Updates:
* `.example.env`, `profiles/demo.env`: Updated `ANOMSTACK_MAX_RUNTIME_SECONDS_TAG` to 900 seconds and `ANOMSTACK_KILL_RUN_AFTER_MINUTES` to 15 minutes. [[1]](diffhunk://#diff-9d7a2448bb252b3987e5cbb36d9d9818b1432313d86287acf8140d48ff911cdaL114-R116) [[2]](diffhunk://#diff-a6fb7ea55dbaa026195e3bda58fbf579652c7dd57413dd12a2ab6c0f8ca11bd9L20-R20)
* `dagster.yaml`, `dagster_docker.yaml`, `dagster_fly.yaml`: Reduced `max_runtime_seconds` to 900 seconds in the `run_monitoring` section. [[1]](diffhunk://#diff-8a6ad27307dd1654855eceb2349da14ed1477fd94a02360c1662a32618eed8e6L14-R14) [[2]](diffhunk://#diff-110b5d2fdf594dd8bd923e9a7e1cfc3b618022ae568e6c4f02495a7f691c329fL75-R75) [[3]](diffhunk://#diff-ac0ef33c3c4e6d66f33ff0e4bc68c7f50a1981c1c88f6147b9509200da536e3bL47-R47)
* [`anomstack/sensors/timeout.py`](diffhunk://#diff-a077b63433846744825823d3639150b960f52abf007939638fbf60662a4c431dL15-R15): Updated `DEFAULT_MINUTES` to 15 minutes for timeout configuration.

### Documentation Updates:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L702-R702): Updated examples to reflect the new 15-minute timeout.
* [`docs/docs/configuration/environment-variables.md`](diffhunk://#diff-ca441f56ef3705f4dcef2fe2d44aaa0b1044ca2831dad2265f76c3f964efd90bL184-R185): Adjusted default values for runtime-related environment variables.
* [`docs/docs/storage-optimization.md`](diffhunk://#diff-74764559edf0355c8f07487a74f948067206d609fb5b13cca1c63a6fbb7817b3L63-R63): Updated `max_runtime_seconds` in the example configuration.

### Docker Image Enhancements:
* `docker/Dockerfile.anomstack_code`, `docker/Dockerfile.anomstack_dashboard`, `docker/Dockerfile.dagster`: Added maintenance scripts for operational use. [[1]](diffhunk://#diff-cd21e938473aee04ec0f34b6b296b93459d39ad2854dcf115f68ec555fc25c53R20-R22) [[2]](diffhunk://#diff-64c2e9317d52618975209a5bc5b3ab39ef3d5d41b818d93bb0ece492d1390af8R29-R31) [[3]](diffhunk://#diff-944566da935337a76134890faefd5cf1d0aade24830e75a605ac3c177bee6b2cR24-R26)