### PR TITLE
Update demo URLs and Fly deployment defaults

### DIFF
--- a/Makefile.md
+++ b/Makefile.md
@@ -571,7 +571,7 @@ make kill-long-runs
 - Requires `FLY_APP` environment variable
 
 ```bash
-export FLY_APP=anomstack-demo
+export FLY_APP=anomstack-live-demo
 make fly-cleanup-preview
 ```
 
@@ -583,7 +583,7 @@ make fly-cleanup-preview
 - Reports disk usage before/after
 
 ```bash
-export FLY_APP=anomstack-demo
+export FLY_APP=anomstack-live-demo
 make fly-cleanup
 ```
 
@@ -595,7 +595,7 @@ make fly-cleanup
 - More thorough than normal cleanup
 
 ```bash
-export FLY_APP=anomstack-demo
+export FLY_APP=anomstack-live-demo
 make fly-cleanup-aggressive
 ```
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 <a href="https://github.com/andrewm4894/anomstack/stargazers">![GitHub Repo stars](https://img.shields.io/github/stars/andrewm4894/anomstack?style=social)</a>
 <a href="https://github.com/andrewm4894/anomstack/releases">![GitHub release (latest by date)](https://img.shields.io/github/v/release/andrewm4894/anomstack?label=Release)</a>
 <a href="https://andrewm4894.github.io/anomstack/">![Docs](https://img.shields.io/badge/Docs-andrewm4894.github.io%2Fanomstack%2F-blue)</a>
-<a href="https://anomstack-demo.fly.dev/">![Dashboard Demo](https://img.shields.io/badge/Dashboard_Demo-anomstack--demo.fly.dev-blue?link=https://anomstack-demo.fly.dev/)</a>
+<a href="https://anomstack-live-demo.fly.dev/">![Dashboard Demo](https://img.shields.io/badge/Dashboard_Demo-anomstack--live--demo.fly.dev-blue?link=https://anomstack-live-demo.fly.dev/)</a>
 <a href="https://github.com/andrewm4894/anomstack/blob/main/LICENSE">![License](https://img.shields.io/badge/License-MIT-yellow.svg)</a>
 <a href="https://github.com/andrewm4894/anomstack/actions/workflows/pytest.yaml">![GitHub PyTest Workflow Status](https://img.shields.io/github/actions/workflow/status/andrewm4894/anomstack/pytest.yaml?label=Tests)</a>
 <a href="https://github.com/andrewm4894/anomstack/actions/workflows/pre-commit.yaml">![GitHub Pre-Commit Workflow Status](https://img.shields.io/github/actions/workflow/status/andrewm4894/anomstack/pre-commit.yaml?label=Pre-Commit)</a>
@@ -27,7 +27,7 @@ Painless open source anomaly detection for your metrics! 📈📉🚀
 
 > _Note: If you are already using Airflow then also checkout the [`airflow-provider-anomaly-detection`](https://github.com/andrewm4894/airflow-provider-anomaly-detection) package._
 
-App screenshots ([live demo](https://anomstack-demo.fly.dev/)):
+App screenshots ([live demo](https://anomstack-live-demo.fly.dev/)):
 
 Homepage:
 ![homepage](./docs/img/dashboard-home.png)
@@ -465,7 +465,7 @@ You can then manage you metrics via PR's in your GitHub repo ([here](https://git
 
 Deploy to [Fly.io](https://fly.io) for production-ready, globally distributed anomaly detection.
 
-**🚀 Live Demo**: https://anomstack-demo.fly.dev
+**🚀 Live Demo**: https://anomstack-live-demo.fly.dev
 
 ```bash
 # New! Automatic .env integration 🎉
@@ -616,7 +616,7 @@ This makes it easy to manage config via environment variables for different depl
 
 You can run Anomstack in a sort of "headless mode" with no UI (if for example you want to use your existing analytics tools etc.).
 
-That said, there is also a fancy [FastHTML](https://fastht.ml/) + [MonsterUI](https://github.com/AnswerDotAI/MonsterUI) (❤️) based dashboard that you can use to visualize your metrics and anomaly scores too (See the demo at https://anomstack-demo.replit.app/).
+That said, there is also a fancy [FastHTML](https://fastht.ml/) + [MonsterUI](https://github.com/AnswerDotAI/MonsterUI) (❤️) based dashboard that you can use to visualize your metrics and anomaly scores too (See the demo at https://anomstack-live-demo.fly.dev/).
 
 Dashboard code lives in [`./dashboard/app.py`](./dashboard/app.py)), use `make dashboard` or `make dashboardd` (to run as a daemon) to start it.
 

--- a/docs/docs/deployment/fly.md
+++ b/docs/docs/deployment/fly.md
@@ -7,10 +7,10 @@ sidebar_position: 3
 Deploy Anomstack to Fly.io for a production-ready, scalable anomaly detection platform in the cloud.
 
 :::tip Live Demo
-🚀 **See it in action**: [https://anomstack-demo.fly.dev](https://anomstack-demo.fly.dev)
+🚀 **See it in action**: [https://anomstack-live-demo.fly.dev](https://anomstack-live-demo.fly.dev)
 
 - **📊 Public Dashboard**: Try the Anomstack interface (no login required)
-- **🔐 Admin Interface**: [/dagster](https://anomstack-demo.fly.dev/dagster) (configurable admin credentials)
+- **🔐 Admin Interface**: [/dagster](https://anomstack-live-demo.fly.dev/dagster) (configurable admin credentials)
 :::
 
 ## Overview

--- a/docs/docs/deployment/overview.md
+++ b/docs/docs/deployment/overview.md
@@ -227,7 +227,7 @@ graph TB
 flowchart TD
     START[👋 Welcome to Anomstack!] --> NEED{What do you need?}
 
-    NEED -->|Quick demo/POC| DEMO[🚀 Try Fly.io Demo<br/>anomstack-demo.fly.dev]
+    NEED -->|Quick demo/POC| DEMO[🚀 Try Fly.io Demo<br/>anomstack-live-demo.fly.dev]
     NEED -->|Full experience| FULL{Infrastructure preference?}
     NEED -->|Just anomaly detection| HEADLESS{Integration needs?}
 
@@ -238,7 +238,7 @@ flowchart TD
     HEADLESS -->|Existing data platform| PLATFORM[🏢 Headless + Your DB<br/>BigQuery/Snowflake/etc]
     HEADLESS -->|Simple integration| MINIMAL[🤖 Docker headless<br/>+ webhooks/API]
 
-    DEMO --> DEMO_LINK[<a href='https://anomstack-demo.fly.dev'>View Live Demo</a>]
+    DEMO --> DEMO_LINK[<a href='https://anomstack-live-demo.fly.dev'>View Live Demo</a>]
     CLOUD --> CLOUD_DOCS[<a href='https://docs.dagster.io/dagster-cloud'>Dagster Cloud Setup</a>]
     DOCKER --> DOCKER_DOCS[<a href='./docker'>Docker Guide</a>]
     LOCAL --> LOCAL_DOCS[<a href='../quickstart'>Quickstart Guide</a>]
@@ -275,7 +275,7 @@ ANOMSTACK_ALERT_WEBHOOK_URL=https://api.company.com/alerts
 
 ### Getting Started
 
-1. **🚀 Quick Demo**: Visit [anomstack-demo.fly.dev](https://anomstack-demo.fly.dev) to see Anomstack in action
+1. **🚀 Quick Demo**: Visit [anomstack-live-demo.fly.dev](https://anomstack-live-demo.fly.dev) to see Anomstack in action
 2. **📖 Follow Guides**: Choose your deployment method from the guides below
 3. **⚙️ Configure Metrics**: Set up your first metric batch
 4. **🔔 Test Alerts**: Configure and test your alerting channels

--- a/docs/docs/features/dashboard.md
+++ b/docs/docs/features/dashboard.md
@@ -34,7 +34,7 @@ Customize your dashboard through:
 
 ## Examples
 
-You can explore a live demo of the Anomstack dashboard at [https://anomstack-demo.replit.app/](https://anomstack-demo.replit.app/). This demo instance showcases various features including:
+You can explore a live demo of the Anomstack dashboard at [https://anomstack-live-demo.fly.dev/](https://anomstack-live-demo.fly.dev/). This demo instance showcases various features including:
 - Real-time metric monitoring
 - Anomaly detection visualization
 - Alert management

--- a/docs/src/pages/index.js
+++ b/docs/src/pages/index.js
@@ -25,7 +25,7 @@ function HomepageHeader() {
           </Link>
           <Link
             className="button button--outline button--secondary button--lg"
-            href="https://anomstack-demo.replit.app/"
+            href="https://anomstack-live-demo.fly.dev/"
             target="_blank"
             style={{marginRight: '10px'}}>
             View Demo

--- a/fly.md
+++ b/fly.md
@@ -1,11 +1,11 @@
 # Anomstack Fly.io Deployment - Quick Start
 
-**🚀 Live Demo**: https://anomstack-demo.fly.dev
+**🚀 Live Demo**: https://anomstack-live-demo.fly.dev
 
 ## Current Architecture
 
-- **📊 Public Dashboard**: https://anomstack-demo.fly.dev/ (no authentication)
-- **🔐 Protected Dagster**: https://anomstack-demo.fly.dev/dagster (configurable admin credentials)
+- **📊 Public Dashboard**: https://anomstack-live-demo.fly.dev/ (no authentication)
+- **🔐 Protected Dagster**: https://anomstack-live-demo.fly.dev/dagster (configurable admin credentials)
 - **🌐 nginx Reverse Proxy**: Routes and protects services
 - **🗄️ SQLite Storage**: Simple, reliable file-based storage on persistent volume
 - **📦 Persistent Volume**: 10GB for DuckDB and models

--- a/fly.toml
+++ b/fly.toml
@@ -1,4 +1,4 @@
-app = "anomstack-demo"
+app = "anomstack-live-demo"
 primary_region = "ord"  # Chicago - you can change this to your preferred region
 
 [experimental]

--- a/profiles/README.md
+++ b/profiles/README.md
@@ -159,7 +159,7 @@ cp .example.env .env
 # Deploy to different environments with different profiles
 ./scripts/deployment/deploy_fly.sh --profile development anomstack-dev
 ./scripts/deployment/deploy_fly.sh --profile production anomstack-prod  
-./scripts/deployment/deploy_fly.sh --profile demo anomstack-demo
+./scripts/deployment/deploy_fly.sh --profile demo anomstack-live-demo
 ```
 
 ### Custom Company Setup

--- a/scripts/deployment/deploy_fly.sh
+++ b/scripts/deployment/deploy_fly.sh
@@ -34,7 +34,7 @@ while [[ $# -gt 0 ]]; do
 done
 
 # Set default app name if not provided
-APP_NAME="${APP_NAME:-anomstack-demo}"
+APP_NAME="${APP_NAME:-anomstack-live-demo}"
 
 # Check if fly CLI is installed and user is logged in
 if ! command -v fly &> /dev/null; then


### PR DESCRIPTION
The demo now runs at https://anomstack-live-demo.fly.dev/. Update the README badge and links, documentation homepage, dashboard and deployment guides, and command examples to use it, including older Replit links.

Set the Fly config and deployment script default to `anomstack-live-demo` so subsequent deployments target the new app. Existing PostHog identifiers and generic custom-app examples retain their meaning.

Validation: Docusaurus production build and changed-file pre-commit checks passed; deployment shell syntax is valid. The live dashboard returned HTTP 200 and unauthenticated Dagster returned HTTP 401.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated dashboard, deployment, homepage, and demo links to the current live demo address.
  * Updated Fly.io cleanup and deployment examples to use the current live demo app name.
  * Updated Dashboard and Dagster links to point to the live deployment.

* **Deployment**
  * The default Fly.io application name now targets the current live demo deployment.
  * Multi-environment deployment examples now use the updated demo application name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->